### PR TITLE
Fix Github Deprecated set-output command

### DIFF
--- a/.github/workflows/changedonlychangelog.yml
+++ b/.github/workflows/changedonlychangelog.yml
@@ -30,8 +30,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.githubToken }}
         run: |
-          echo ::set-output name=file_list::$(curl -H 'Accept: application/vnd.github.v3+json'  -H 'Authorization: Bearer ${{ secrets.githubToken }}' https://api.github.com/repos/${{ inputs.owner_repo }}/pulls/${{ inputs.pr_num }}/files | jq -r .[].filename)
+          echo "{file_list}={$(curl -H 'Accept: application/vnd.github.v3+json'  -H 'Authorization: Bearer ${{ secrets.githubToken }}' https://api.github.com/repos/${{ inputs.owner_repo }}/pulls/${{ inputs.pr_num }}/files | jq -r .[].filename)}" >> $GITHUB_OUTPUT
       - run: "echo URL called: GET /repos/${{ inputs.owner_repo }}/pulls/${{ inputs.pr_num }}/files"
       - name: Set output vars
         id: set_output
-        run: '[[ "${{steps.get_file_data.outputs.file_list}}" == "CHANGELOG.md" ]] && echo "::set-output name=changelog_only::true" || echo "::set-output name=changelog_only::false"'
+        run: '[[ "${{steps.get_file_data.outputs.file_list}}" == "CHANGELOG.md" ]] && echo "{changelog_only}={true}" >> $GITHUB_OUTPUT || echo "{changelog_only}={false}" >> $GITHUB_OUTPUT'

--- a/.github/workflows/tagandrelease.yml
+++ b/.github/workflows/tagandrelease.yml
@@ -28,7 +28,7 @@ jobs:
                   GITHUB_PR_TITLE="${GITHUB_PR_TITLE^^}"
                   GITHUB_PR_TITLE="${GITHUB_PR_TITLE#"CUT VERSION "}"
                   GITHUB_PR_TAG="${GITHUB_PR_TITLE%% *}"
-                  echo "::set-output name=version::$GITHUB_PR_TAG"
+                  echo "echo {version}={$GITHUB_PR_TAG} >> $GITHUB_OUTPUT"
             - name: Create Release
               uses: actions/github-script@v3
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
  - Add `version` output to tagandrelease.yml action
  - Add `on.workflow_call.secrets.github-token` to tagandrelease.yml action
  - Add `changedonlychangelog.yml` action
+ - Fix Github Deprecated set-output command (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)


### PR DESCRIPTION
I think there was a security vulnerability. This follows the new setup they recommend: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/