### PR TITLE
Fix worksheetTitle values in `set-requires-testing-status.yml`

### DIFF
--- a/.github/workflows/set-requires-testing-status.yml
+++ b/.github/workflows/set-requires-testing-status.yml
@@ -56,7 +56,7 @@ jobs:
         PR_NUMBER_COLUMN: "O"
         REPO_COLUMN: "B"
         STATUS_COLUMN: "D"
-        WORKSHEET_TITLE: "Dev QA"
+        WORKSHEET_TITLE: ${{ inputs.worksheet_title }}
     - name: find_matching_row
       if: inputs.pr_number != ''
       id: find_matching_row
@@ -77,7 +77,7 @@ jobs:
           [
             { "command": "updateData",
             "args": {
-                "worksheetTitle": "$WORKSHEET_TITLE",
+                "worksheetTitle": ${{ env.WORKSHEET_TITLE }},
                 "range": "${{ env.STATUS_COLUMN }}${{steps.find_matching_row.outputs.ROW_NUMBER }}",
                 "data":[["REQUIRES TESTING"]]
               }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
  - Add `append-testing-sheet-entry.yml` action
  - Add PR number to data inserted in `append-testing-sheet-entry.yml`
  - Use PR number to match rows in `set-requires-testing-status.yml`
-
+ - Fix worksheetTitle values in `set-requires-testing-status.yml`


### PR DESCRIPTION
1. Fix update_worksheet's worksheetTitle variable

   This is a random guess at what caused the issue Hugh described:
   > read_worksheet was successful
   > update_worksheet used the wrong worksheetTitle (it uses the first worksheet, rather than "Dev QA")

2. Change to make read_worksheet's worksheetTitle not hardcoded.
---

Testing to make sure nothing has been broken:
Merge in a content-hub PR and check its status in "Dev QA" is updated to "REQUIRES TESTING"