### PR TITLE
Add :current tag guard to reusable workflows, extract create-multi-arch-manifest, remove caller SHA trust

### DIFF
--- a/.github/workflows/build-and-deploy-ecr-image.yml
+++ b/.github/workflows/build-and-deploy-ecr-image.yml
@@ -67,6 +67,14 @@ jobs:
     name: Build and Deploy ECR Image
     runs-on: ${{ inputs.runner }}
     steps:
+      - name: Validate tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
+            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/build-and-deploy-ecr-image.yml
+++ b/.github/workflows/build-and-deploy-ecr-image.yml
@@ -70,10 +70,13 @@ jobs:
       - name: Validate tag
         run: |
           TAG="${{ inputs.tag }}"
-          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
-            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
-            exit 1
-          fi
+          PROTECTED_TAGS=("current" "latest" "commentator_test_current")
+          for protected in "${PROTECTED_TAGS[@]}"; do
+            if [[ "$TAG" =~ ^${protected}(-amd64|-arm64)?$ ]]; then
+              echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':${protected}' tag."
+              exit 1
+            fi
+          done
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -1,0 +1,113 @@
+# This workflow builds a Docker image using Buildx and outputs it as a GHA artifact.
+# It does NOT have AWS credentials — the image is pushed to ECR by a separate push-ecr-image.yml workflow.
+# This separation ensures that Dockerfile code execution cannot access AWS credentials.
+#
+# The image is exported as an OCI tarball, compressed with zstd, and uploaded as a GHA artifact.
+name: Build ECR Image
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag for the Docker image (used in artifact naming)."
+        required: true
+        type: string
+      dockerfile:
+        description: "The Dockerfile to build"
+        required: true
+        type: string
+      artifact-name:
+        description: "Name for the uploaded artifact (must be unique within the workflow run)"
+        required: true
+        type: string
+      build-args:
+        description: "Docker build arguments (multiline string, one per line in KEY=VALUE format)"
+        required: false
+        type: string
+        default: ""
+      use-ssh:
+        description: "Whether to use SSH for private repositories"
+        required: false
+        type: boolean
+        default: false
+      platforms:
+        description: "Target platform for the build (e.g., linux/amd64 or linux/arm64)"
+        required: false
+        type: string
+        default: "linux/amd64"
+      runner:
+        description: "The type of runner to use"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      compression-level:
+        description: "Zstd compression level for the OCI tarball (1-19, higher = slower but smaller)"
+        required: false
+        type: number
+        default: 3
+    secrets:
+      ssh-private-key:
+        description: "SSH keys for accessing private repositories during build."
+        required: false
+    outputs:
+      artifact-name:
+        description: "Name of the uploaded artifact containing the OCI tarball"
+        value: ${{ jobs.build-ecr-image.outputs.artifact-name }}
+
+jobs:
+  build-ecr-image:
+    name: Build ECR Image
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      # Configure deploy SSH keys to download private repos
+      # Note, you need to add Repo URL to the key comment so this action knows what to do with it
+      # Details: https://github.com/SpalkLtd/ssh-agent#support-for-github-deploy-keys
+      # Automated key rolling script: https://github.com/SpalkLtd/utils/blob/main/actions/deploy_keys.sh
+      - name: Allow access to Spalk Private repositories
+        uses: SpalkLtd/ssh-agent@26e485b72da53538f103f191ddd325d2f2ef3771
+        if: ${{ inputs.use-ssh }}
+        with:
+          ssh-private-key: ${{ secrets.ssh-private-key }}
+
+      # This action copies the ~/.gitconfig and ~/.ssh files from the host, that were configured by the previous SpalkLtd/ssh-agent
+      # step to correctly access github. It corrects the paths. We are not copying actual private keys, they are held in-memory at all
+      # times by the ssh-agent, and crypto functions are done over the env.SSH_AUTH_SOCK socket.
+      - name: Collect Git and SSH config files
+        if: ${{ inputs.use-ssh }}
+        run: |
+          cp -f ~/.gitconfig docker/gitconfig/gitconfig
+          cp -r ~/.ssh/* docker/ssh
+          sed 's|/home/runner|/root|g' -i.bak docker/ssh/config
+
+      - name: Build docker image to OCI tarball
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          ssh: ${{ inputs.use-ssh && secrets.ssh-private-key != '' && format('default={0}', env.SSH_AUTH_SOCK) || '' }}
+          context: .
+          build-args: ${{ inputs.build-args }}
+          push: false
+          tags: image:${{ inputs.tag }}
+          platforms: ${{ inputs.platforms }}
+          cache-from: type=gha,scope=${{ inputs.artifact-name }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.artifact-name }}
+          file: ${{ inputs.dockerfile }}
+          outputs: type=oci,dest=/tmp/image.tar
+
+      - name: Compress OCI tarball
+        run: zstd -${{ inputs.compression-level }} -T0 /tmp/image.tar -o /tmp/image.tar.zst
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/image.tar.zst
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/cleanup-ecr-images.yml
+++ b/.github/workflows/cleanup-ecr-images.yml
@@ -40,10 +40,13 @@ jobs:
       - name: Validate tag prefix
         run: |
           PREFIX="${{ inputs.tag-prefix }}"
-          if [[ "current" == "$PREFIX"* ]]; then
-            echo "::error::Refusing to clean up images matching reserved tag 'current'. Tag prefix '${PREFIX}' would match ':current' tags."
-            exit 1
-          fi
+          PROTECTED_TAGS=("current" "latest" "commentator_test_current")
+          for tag in "${PROTECTED_TAGS[@]}"; do
+            if [[ "$tag" == "$PREFIX"* ]]; then
+              echo "::error::Refusing to clean up images matching reserved tag '${tag}'. Tag prefix '${PREFIX}' would match ':${tag}' tags."
+              exit 1
+            fi
+          done
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/cleanup-ecr-images.yml
+++ b/.github/workflows/cleanup-ecr-images.yml
@@ -37,6 +37,14 @@ jobs:
     name: Clean up PR ECR Images
     runs-on: ubuntu-latest
     steps:
+      - name: Validate tag prefix
+        run: |
+          PREFIX="${{ inputs.tag-prefix }}"
+          if [[ "current" == "$PREFIX"* ]]; then
+            echo "::error::Refusing to clean up images matching reserved tag 'current'. Tag prefix '${PREFIX}' would match ':current' tags."
+            exit 1
+          fi
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:

--- a/.github/workflows/create-multi-arch-manifest.yml
+++ b/.github/workflows/create-multi-arch-manifest.yml
@@ -53,11 +53,13 @@ jobs:
           role-to-assume: ${{ inputs.aws-role }}
           aws-region: ${{ inputs.aws-region }}
 
-      - name: Login to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Login to primary ECR
+        run: |
+          crane auth login 496668274218.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com \
+            -u AWS -p "$(aws ecr get-login-password --region ${{ inputs.aws-region }})"
 
       - name: Create and replicate multi-arch manifest
         env:
@@ -70,12 +72,16 @@ jobs:
           set -eo pipefail
 
           PRIMARY_REGISTRY="496668274218.dkr.ecr.${AWS_REGION_INPUT}.amazonaws.com"
+          BASE_IMAGE="${PRIMARY_REGISTRY}/${REPO}"
 
-          echo "Creating multi-arch manifest: ${PRIMARY_REGISTRY}/${REPO}:${TAG}"
-          docker buildx imagetools create \
-            --tag ${PRIMARY_REGISTRY}/${REPO}:${TAG} \
-            ${PRIMARY_REGISTRY}/${REPO}:${TAG}-amd64 \
-            ${PRIMARY_REGISTRY}/${REPO}:${TAG}-arm64
+          echo "Creating multi-arch manifest: ${BASE_IMAGE}:${TAG}"
+          crane index append \
+            --tag ${BASE_IMAGE}:${TAG} \
+            --manifest ${BASE_IMAGE}:${TAG}-amd64 \
+            --manifest ${BASE_IMAGE}:${TAG}-arm64
+
+          echo "Verifying manifest list:"
+          crane manifest ${BASE_IMAGE}:${TAG} | jq .
 
           # Replicate to media regions
           regions=()
@@ -84,12 +90,15 @@ jobs:
           done < <(echo "$MEDIA_REGIONS" | jq -r '.[]')
 
           for region in "${regions[@]}"; do
-            echo "=== Replicating manifest to region: $region ==="
+            echo "=== Copying manifest to region: $region ==="
             MEDIA_REGISTRY="496668274218.dkr.ecr.${region}.amazonaws.com"
-            aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${MEDIA_REGISTRY}
-            docker buildx imagetools create \
-              --tag ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG} \
-              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}-amd64 \
-              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}-arm64
+
+            crane auth login ${MEDIA_REGISTRY} \
+              -u AWS -p "$(aws ecr get-login-password --region ${region})"
+
+            crane copy \
+              ${BASE_IMAGE}:${TAG} \
+              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}
+
             echo "[$region] Successfully replicated manifest"
           done

--- a/.github/workflows/create-multi-arch-manifest.yml
+++ b/.github/workflows/create-multi-arch-manifest.yml
@@ -1,0 +1,95 @@
+# This workflow creates a multi-architecture Docker manifest from per-architecture
+# images and replicates it to media region ECR repositories.
+# It is designed to be called after separate amd64 and arm64 builds have completed.
+#
+# It will require setting up correct IAM authorization, which is detailed in README.md.
+name: Create Multi-Arch Manifest
+
+on:
+  workflow_call:
+    inputs:
+      aws-role:
+        description: "AWS IAM role to assume"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS region for primary ECR registry"
+        required: true
+        type: string
+      repository-name:
+        description: "Primary ECR repository name"
+        required: true
+        type: string
+      tag:
+        description: "Base image tag (without architecture suffix). Expects {tag}-amd64 and {tag}-arm64 to exist."
+        required: true
+        type: string
+      media-region-repository-name:
+        description: "ECR repository name in media regions. Defaults to repository-name if not specified."
+        required: false
+        type: string
+      media-regions:
+        description: 'List of media regions to replicate to (JSON array format, e.g. ["us-east-1", "eu-west-1"])'
+        required: false
+        type: string
+        default: "[]"
+
+jobs:
+  create-multi-arch-manifest:
+    name: Create Multi-Arch Manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
+            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
+            exit 1
+          fi
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Create and replicate multi-arch manifest
+        env:
+          AWS_REGION_INPUT: ${{ inputs.aws-region }}
+          REPO: ${{ inputs.repository-name }}
+          MEDIA_REPO: ${{ inputs.media-region-repository-name || inputs.repository-name }}
+          TAG: ${{ inputs.tag }}
+          MEDIA_REGIONS: ${{ inputs.media-regions }}
+        run: |
+          set -eo pipefail
+
+          PRIMARY_REGISTRY="496668274218.dkr.ecr.${AWS_REGION_INPUT}.amazonaws.com"
+
+          echo "Creating multi-arch manifest: ${PRIMARY_REGISTRY}/${REPO}:${TAG}"
+          docker buildx imagetools create \
+            --tag ${PRIMARY_REGISTRY}/${REPO}:${TAG} \
+            ${PRIMARY_REGISTRY}/${REPO}:${TAG}-amd64 \
+            ${PRIMARY_REGISTRY}/${REPO}:${TAG}-arm64
+
+          # Replicate to media regions
+          regions=()
+          while IFS= read -r region; do
+            regions+=("$region")
+          done < <(echo "$MEDIA_REGIONS" | jq -r '.[]')
+
+          for region in "${regions[@]}"; do
+            echo "=== Replicating manifest to region: $region ==="
+            MEDIA_REGISTRY="496668274218.dkr.ecr.${region}.amazonaws.com"
+            aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${MEDIA_REGISTRY}
+            docker buildx imagetools create \
+              --tag ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG} \
+              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}-amd64 \
+              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}-arm64
+            echo "[$region] Successfully replicated manifest"
+          done

--- a/.github/workflows/create-multi-arch-manifest.yml
+++ b/.github/workflows/create-multi-arch-manifest.yml
@@ -42,10 +42,13 @@ jobs:
       - name: Validate tag
         run: |
           TAG="${{ inputs.tag }}"
-          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
-            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
-            exit 1
-          fi
+          PROTECTED_TAGS=("current" "latest" "commentator_test_current")
+          for protected in "${PROTECTED_TAGS[@]}"; do
+            if [[ "$TAG" =~ ^${protected}(-amd64|-arm64)?$ ]]; then
+              echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':${protected}' tag."
+              exit 1
+            fi
+          done
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/push-ecr-image.yml
+++ b/.github/workflows/push-ecr-image.yml
@@ -1,0 +1,146 @@
+# This workflow downloads a pre-built OCI image artifact and pushes it to Amazon ECR.
+# It does NOT check out caller repo code, does NOT have SSH keys, and does NOT execute any Dockerfile.
+# This separation ensures that AWS credentials are never available during code execution.
+#
+# It supports multi-region deployments by replicating the image to media region ECR repositories.
+#
+# It will require setting up correct IAM authorization, which is detailed in README.md.
+name: Push ECR Image
+
+on:
+  workflow_call:
+    inputs:
+      aws-role:
+        description: "AWS IAM role to assume"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS region for deployment"
+        required: true
+        type: string
+      repository-name:
+        description: "The ECR repository name to push to"
+        required: true
+        type: string
+      tag:
+        description: "Tag for the Docker image in ECR"
+        required: true
+        type: string
+      artifact-name:
+        description: "Name of the artifact containing the OCI tarball (from build-ecr-image.yml)"
+        required: true
+        type: string
+      media-region-repository-name:
+        description: "The media region ECR repository name"
+        required: false
+        type: string
+      media-regions:
+        description: 'List of media regions to push to (JSON array format, e.g. ["us-east-1", "eu-west-1"])'
+        required: false
+        type: string
+        default: "[]"
+    outputs:
+      digest:
+        description: "Digest of the pushed image"
+        value: ${{ jobs.push-ecr-image.outputs.digest }}
+
+jobs:
+  push-ecr-image:
+    name: Push ECR Image
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: Validate tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
+            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
+            exit 1
+          fi
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Login to dev registry
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        env:
+          AWS_REGION: us-east-2
+
+      - name: Login to prod registry
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Download artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/artifact
+
+      - name: Decompress OCI tarball
+        run: zstd -d /tmp/artifact/image.tar.zst -o /tmp/image.tar
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@31b88afe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Push image to ECR
+        id: push
+        env:
+          ECR_REGISTRY: "496668274218.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com"
+          REPOSITORY_NAME: ${{ inputs.repository-name }}
+          IMAGE_TAG: ${{ inputs.tag }}
+        run: |
+          set -eo pipefail
+
+          DEST="${ECR_REGISTRY}/${REPOSITORY_NAME}:${IMAGE_TAG}"
+          echo "Pushing to ${DEST}"
+
+          crane push /tmp/image.tar "${DEST}"
+
+          DIGEST=$(crane digest "${DEST}")
+          echo "Pushed image digest: ${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: ${{ inputs.media-region-repository-name != '' && inputs.media-regions != '[]' }}
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Push to ECR in media regions
+        if: ${{ inputs.media-region-repository-name != '' && inputs.media-regions != '[]' }}
+        env:
+          MEDIA_REGIONS: ${{ inputs.media-regions }}
+          AWS_REGION_INPUT: ${{ inputs.aws-region }}
+          REPOSITORY_NAME: ${{ inputs.repository-name }}
+          IMAGE_TAG: ${{ inputs.tag }}
+          MEDIA_REGION_REPOSITORY_NAME: ${{ inputs.media-region-repository-name }}
+          PUSH_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -eo pipefail
+
+          # Parse media regions from JSON input
+          regions=()
+          while IFS= read -r region; do
+            regions+=("$region")
+          done < <(echo "$MEDIA_REGIONS" | jq -r '.[]')
+
+          SOURCE_IMAGE="496668274218.dkr.ecr.$AWS_REGION_INPUT.amazonaws.com/$REPOSITORY_NAME:$IMAGE_TAG"
+
+          echo "Source image: $SOURCE_IMAGE"
+          echo "Source image digest: $PUSH_DIGEST"
+
+          # Loop through each region
+          for region in "${regions[@]}"; do
+            echo "=== Processing region: $region ==="
+            aws ecr get-login-password --region $region | docker login --username AWS --password-stdin 496668274218.dkr.ecr.$region.amazonaws.com
+
+            DEST_IMAGE="496668274218.dkr.ecr.$region.amazonaws.com/$MEDIA_REGION_REPOSITORY_NAME:$IMAGE_TAG"
+
+            echo "[$region] Copying image from $SOURCE_IMAGE to $DEST_IMAGE"
+            docker buildx imagetools create --tag $DEST_IMAGE $SOURCE_IMAGE
+
+            echo "[$region] Successfully pushed to region"
+          done

--- a/.github/workflows/push-ecr-image.yml
+++ b/.github/workflows/push-ecr-image.yml
@@ -65,15 +65,15 @@ jobs:
           role-to-assume: ${{ inputs.aws-role }}
           aws-region: ${{ inputs.aws-region }}
 
-      - name: Login to dev registry
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-        env:
-          AWS_REGION: us-east-2
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
-      - name: Login to prod registry
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-        env:
-          AWS_REGION: us-east-1
+      - name: Login to primary ECR registries
+        run: |
+          for region in us-east-2 us-east-1; do
+            crane auth login 496668274218.dkr.ecr.${region}.amazonaws.com \
+              -u AWS -p "$(aws ecr get-login-password --region ${region})"
+          done
 
       - name: Download artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -83,9 +83,6 @@ jobs:
 
       - name: Decompress OCI tarball
         run: zstd -d /tmp/artifact/image.tar.zst -o /tmp/image.tar
-
-      - name: Install crane
-        uses: imjasonh/setup-crane@31b88afe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Push image to ECR
         id: push
@@ -105,10 +102,6 @@ jobs:
           echo "Pushed image digest: ${DIGEST}"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        if: ${{ inputs.media-region-repository-name != '' && inputs.media-regions != '[]' }}
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Push to ECR in media regions
         if: ${{ inputs.media-region-repository-name != '' && inputs.media-regions != '[]' }}
         env:
@@ -117,11 +110,9 @@ jobs:
           REPOSITORY_NAME: ${{ inputs.repository-name }}
           IMAGE_TAG: ${{ inputs.tag }}
           MEDIA_REGION_REPOSITORY_NAME: ${{ inputs.media-region-repository-name }}
-          PUSH_DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           set -eo pipefail
 
-          # Parse media regions from JSON input
           regions=()
           while IFS= read -r region; do
             regions+=("$region")
@@ -129,18 +120,17 @@ jobs:
 
           SOURCE_IMAGE="496668274218.dkr.ecr.$AWS_REGION_INPUT.amazonaws.com/$REPOSITORY_NAME:$IMAGE_TAG"
 
-          echo "Source image: $SOURCE_IMAGE"
-          echo "Source image digest: $PUSH_DIGEST"
-
-          # Loop through each region
           for region in "${regions[@]}"; do
             echo "=== Processing region: $region ==="
-            aws ecr get-login-password --region $region | docker login --username AWS --password-stdin 496668274218.dkr.ecr.$region.amazonaws.com
+            MEDIA_REGISTRY="496668274218.dkr.ecr.$region.amazonaws.com"
 
-            DEST_IMAGE="496668274218.dkr.ecr.$region.amazonaws.com/$MEDIA_REGION_REPOSITORY_NAME:$IMAGE_TAG"
+            crane auth login ${MEDIA_REGISTRY} \
+              -u AWS -p "$(aws ecr get-login-password --region $region)"
 
+            DEST_IMAGE="${MEDIA_REGISTRY}/$MEDIA_REGION_REPOSITORY_NAME:$IMAGE_TAG"
             echo "[$region] Copying image from $SOURCE_IMAGE to $DEST_IMAGE"
-            docker buildx imagetools create --tag $DEST_IMAGE $SOURCE_IMAGE
+
+            crane copy $SOURCE_IMAGE $DEST_IMAGE
 
             echo "[$region] Successfully pushed to region"
           done

--- a/.github/workflows/push-ecr-image.yml
+++ b/.github/workflows/push-ecr-image.yml
@@ -54,10 +54,13 @@ jobs:
       - name: Validate tag
         run: |
           TAG="${{ inputs.tag }}"
-          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
-            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
-            exit 1
-          fi
+          PROTECTED_TAGS=("current" "latest" "commentator_test_current")
+          for protected in "${PROTECTED_TAGS[@]}"; do
+            if [[ "$TAG" =~ ^${protected}(-amd64|-arm64)?$ ]]; then
+              echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':${protected}' tag."
+              exit 1
+            fi
+          done
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0


### PR DESCRIPTION
- Add tag validation step to build-and-deploy-ecr-image.yml and
  create-multi-arch-manifest.yml reusable workflows that rejects the
  reserved ':current' tag before assuming any AWS credentials
- Extract create-multi-arch-manifest.yml as a new reusable workflow so
  all release jobs go through SHA-pinned callees (eliminating the need
  for per-service caller workflow SHA trust)
- Update all 6 service release-published.yml to call the reusable
  manifest workflow instead of inline docker buildx commands
- Remove gha_release_caller_workflow_shas variable from IAM module,
  root module, deployments, and tfvars (no longer needed)
- Add create-multi-arch-manifest.yml to gha_reusable_workflows trusted list

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
