### PR TITLE
Fix reusable workflows: use Docker tarball format and standardise on crane

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -2,7 +2,7 @@
 # It does NOT have AWS credentials — the image is pushed to ECR by a separate push-ecr-image.yml workflow.
 # This separation ensures that Dockerfile code execution cannot access AWS credentials.
 #
-# The image is exported as an OCI tarball, compressed with zstd, and uploaded as a GHA artifact.
+# The image is exported as a Docker tarball, compressed with zstd, and uploaded as a GHA artifact.
 name: Build ECR Image
 
 on:
@@ -41,7 +41,7 @@ on:
         type: string
         default: "ubuntu-latest"
       compression-level:
-        description: "Zstd compression level for the OCI tarball (1-19, higher = slower but smaller)"
+        description: "Zstd compression level for the image tarball (1-19, higher = slower but smaller)"
         required: false
         type: number
         default: 3
@@ -51,7 +51,7 @@ on:
         required: false
     outputs:
       artifact-name:
-        description: "Name of the uploaded artifact containing the OCI tarball"
+        description: "Name of the uploaded artifact containing the image tarball"
         value: ${{ jobs.build-ecr-image.outputs.artifact-name }}
 
 jobs:
@@ -87,7 +87,7 @@ jobs:
           cp -r ~/.ssh/* docker/ssh
           sed 's|/home/runner|/root|g' -i.bak docker/ssh/config
 
-      - name: Build docker image to OCI tarball
+      - name: Build docker image to tarball
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           ssh: ${{ inputs.use-ssh && secrets.ssh-private-key != '' && format('default={0}', env.SSH_AUTH_SOCK) || '' }}
@@ -99,9 +99,9 @@ jobs:
           cache-from: type=gha,scope=${{ inputs.artifact-name }}
           cache-to: type=gha,mode=max,scope=${{ inputs.artifact-name }}
           file: ${{ inputs.dockerfile }}
-          outputs: type=oci,dest=/tmp/image.tar
+          outputs: type=docker,dest=/tmp/image.tar
 
-      - name: Compress OCI tarball
+      - name: Compress image tarball
         run: zstd -${{ inputs.compression-level }} -T0 /tmp/image.tar -o /tmp/image.tar.zst
 
       - name: Upload artifact

--- a/.github/workflows/create-multi-arch-manifest.yml
+++ b/.github/workflows/create-multi-arch-manifest.yml
@@ -42,10 +42,13 @@ jobs:
       - name: Validate tag
         run: |
           TAG="${{ inputs.tag }}"
-          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
-            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
-            exit 1
-          fi
+          PROTECTED_TAGS=("current" "latest" "commentator_test_current")
+          for protected in "${PROTECTED_TAGS[@]}"; do
+            if [[ "$TAG" =~ ^${protected}(-amd64|-arm64)?$ ]]; then
+              echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':${protected}' tag."
+              exit 1
+            fi
+          done
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -53,11 +56,13 @@ jobs:
           role-to-assume: ${{ inputs.aws-role }}
           aws-region: ${{ inputs.aws-region }}
 
-      - name: Login to ECR
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Login to primary ECR
+        run: |
+          crane auth login 496668274218.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com \
+            -u AWS -p "$(aws ecr get-login-password --region ${{ inputs.aws-region }})"
 
       - name: Create and replicate multi-arch manifest
         env:
@@ -70,12 +75,16 @@ jobs:
           set -eo pipefail
 
           PRIMARY_REGISTRY="496668274218.dkr.ecr.${AWS_REGION_INPUT}.amazonaws.com"
+          BASE_IMAGE="${PRIMARY_REGISTRY}/${REPO}"
 
-          echo "Creating multi-arch manifest: ${PRIMARY_REGISTRY}/${REPO}:${TAG}"
-          docker buildx imagetools create \
-            --tag ${PRIMARY_REGISTRY}/${REPO}:${TAG} \
-            ${PRIMARY_REGISTRY}/${REPO}:${TAG}-amd64 \
-            ${PRIMARY_REGISTRY}/${REPO}:${TAG}-arm64
+          echo "Creating multi-arch manifest: ${BASE_IMAGE}:${TAG}"
+          crane index append \
+            --tag ${BASE_IMAGE}:${TAG} \
+            --manifest ${BASE_IMAGE}:${TAG}-amd64 \
+            --manifest ${BASE_IMAGE}:${TAG}-arm64
+
+          echo "Verifying manifest list:"
+          crane manifest ${BASE_IMAGE}:${TAG} | jq .
 
           # Replicate to media regions
           regions=()
@@ -84,12 +93,15 @@ jobs:
           done < <(echo "$MEDIA_REGIONS" | jq -r '.[]')
 
           for region in "${regions[@]}"; do
-            echo "=== Replicating manifest to region: $region ==="
+            echo "=== Copying manifest to region: $region ==="
             MEDIA_REGISTRY="496668274218.dkr.ecr.${region}.amazonaws.com"
-            aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${MEDIA_REGISTRY}
-            docker buildx imagetools create \
-              --tag ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG} \
-              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}-amd64 \
-              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}-arm64
+
+            crane auth login ${MEDIA_REGISTRY} \
+              -u AWS -p "$(aws ecr get-login-password --region ${region})"
+
+            crane copy \
+              ${BASE_IMAGE}:${TAG} \
+              ${MEDIA_REGISTRY}/${MEDIA_REPO}:${TAG}
+
             echo "[$region] Successfully replicated manifest"
           done

--- a/.github/workflows/push-ecr-image.yml
+++ b/.github/workflows/push-ecr-image.yml
@@ -1,4 +1,4 @@
-# This workflow downloads a pre-built OCI image artifact and pushes it to Amazon ECR.
+# This workflow downloads a pre-built Docker image artifact and pushes it to Amazon ECR.
 # It does NOT check out caller repo code, does NOT have SSH keys, and does NOT execute any Dockerfile.
 # This separation ensures that AWS credentials are never available during code execution.
 #
@@ -27,7 +27,7 @@ on:
         required: true
         type: string
       artifact-name:
-        description: "Name of the artifact containing the OCI tarball (from build-ecr-image.yml)"
+        description: "Name of the artifact containing the image tarball (from build-ecr-image.yml)"
         required: true
         type: string
       media-region-repository-name:
@@ -54,10 +54,13 @@ jobs:
       - name: Validate tag
         run: |
           TAG="${{ inputs.tag }}"
-          if [[ "$TAG" =~ ^current(-amd64|-arm64)?$ ]]; then
-            echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':current' tag."
-            exit 1
-          fi
+          PROTECTED_TAGS=("current" "latest" "commentator_test_current")
+          for protected in "${PROTECTED_TAGS[@]}"; do
+            if [[ "$TAG" =~ ^${protected}(-amd64|-arm64)?$ ]]; then
+              echo "::error::Refusing to push to reserved tag ':${TAG}'. This workflow must not overwrite the ':${protected}' tag."
+              exit 1
+            fi
+          done
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -65,15 +68,13 @@ jobs:
           role-to-assume: ${{ inputs.aws-role }}
           aws-region: ${{ inputs.aws-region }}
 
-      - name: Login to dev registry
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-        env:
-          AWS_REGION: us-east-2
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
-      - name: Login to prod registry
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-        env:
-          AWS_REGION: us-east-1
+      - name: Login to primary ECR
+        run: |
+          crane auth login 496668274218.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com \
+            -u AWS -p "$(aws ecr get-login-password --region ${{ inputs.aws-region }})"
 
       - name: Download artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -81,11 +82,8 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: /tmp/artifact
 
-      - name: Decompress OCI tarball
+      - name: Decompress image tarball
         run: zstd -d /tmp/artifact/image.tar.zst -o /tmp/image.tar
-
-      - name: Install crane
-        uses: imjasonh/setup-crane@31b88afe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Push image to ECR
         id: push
@@ -105,11 +103,7 @@ jobs:
           echo "Pushed image digest: ${DIGEST}"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        if: ${{ inputs.media-region-repository-name != '' && inputs.media-regions != '[]' }}
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      - name: Push to ECR in media regions
+      - name: Copy to media regions
         if: ${{ inputs.media-region-repository-name != '' && inputs.media-regions != '[]' }}
         env:
           MEDIA_REGIONS: ${{ inputs.media-regions }}
@@ -117,11 +111,9 @@ jobs:
           REPOSITORY_NAME: ${{ inputs.repository-name }}
           IMAGE_TAG: ${{ inputs.tag }}
           MEDIA_REGION_REPOSITORY_NAME: ${{ inputs.media-region-repository-name }}
-          PUSH_DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           set -eo pipefail
 
-          # Parse media regions from JSON input
           regions=()
           while IFS= read -r region; do
             regions+=("$region")
@@ -129,18 +121,15 @@ jobs:
 
           SOURCE_IMAGE="496668274218.dkr.ecr.$AWS_REGION_INPUT.amazonaws.com/$REPOSITORY_NAME:$IMAGE_TAG"
 
-          echo "Source image: $SOURCE_IMAGE"
-          echo "Source image digest: $PUSH_DIGEST"
-
-          # Loop through each region
           for region in "${regions[@]}"; do
-            echo "=== Processing region: $region ==="
-            aws ecr get-login-password --region $region | docker login --username AWS --password-stdin 496668274218.dkr.ecr.$region.amazonaws.com
+            echo "=== Copying image to region: $region ==="
+            MEDIA_REGISTRY="496668274218.dkr.ecr.$region.amazonaws.com"
 
-            DEST_IMAGE="496668274218.dkr.ecr.$region.amazonaws.com/$MEDIA_REGION_REPOSITORY_NAME:$IMAGE_TAG"
+            crane auth login ${MEDIA_REGISTRY} \
+              -u AWS -p "$(aws ecr get-login-password --region ${region})"
 
-            echo "[$region] Copying image from $SOURCE_IMAGE to $DEST_IMAGE"
-            docker buildx imagetools create --tag $DEST_IMAGE $SOURCE_IMAGE
+            DEST_IMAGE="${MEDIA_REGISTRY}/${MEDIA_REGION_REPOSITORY_NAME}:${IMAGE_TAG}"
+            crane copy ${SOURCE_IMAGE} ${DEST_IMAGE}
 
-            echo "[$region] Successfully pushed to region"
+            echo "[$region] Successfully copied image"
           done


### PR DESCRIPTION
- build-ecr-image: Change output from type=oci to type=docker to fix
  crane push "manifest.json not found" error
- push-ecr-image: Replace docker buildx imagetools with crane copy for
  media region replication, remove buildx dependency
- create-multi-arch-manifest: Use crane index append and crane copy
  instead of docker buildx imagetools create
- Bump crane from v0.4 to v0.5 across push and manifest workflows
- Expand protected tag validation to cover current, latest, and
  commentator_test_current

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- SIBLING_PRS_START -->
## Sibling PRs

- https://github.com/SpalkLtd/content-deleter/pull/8
- https://github.com/SpalkLtd/content-hub/pull/4041
- https://github.com/SpalkLtd/github-reusable-workflows/pull/19
- https://github.com/SpalkLtd/grafana/pull/167
- https://github.com/SpalkLtd/social-media/pull/781
- https://github.com/SpalkLtd/spalk-ffmpeg/pull/78
- https://github.com/SpalkLtd/spalk-janus/pull/64
- https://github.com/SpalkLtd/spalk-live-sync-api/pull/3766
- https://github.com/SpalkLtd/spalk-nginx/pull/603
- https://github.com/SpalkLtd/spalk-stack/pull/542
- https://github.com/SpalkLtd/synchroniser/pull/1694
- https://github.com/SpalkLtd/vod-processing-service/pull/106
<!-- SIBLING_PRS_END -->
