### PR TITLE
Add ECR base image pull role and optional ECR login to build-ecr-image workflow

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -1,6 +1,10 @@
 # This workflow builds a Docker image using Buildx and outputs it as a GHA artifact.
-# It does NOT have AWS credentials — the image is pushed to ECR by a separate push-ecr-image.yml workflow.
-# This separation ensures that Dockerfile code execution cannot access AWS credentials.
+# The image is pushed to ECR by a separate push-ecr-image.yml workflow.
+#
+# By default, this workflow has NO AWS credentials, ensuring Dockerfile code cannot access them.
+# When the Dockerfile pulls base images from a private ECR repo (e.g. spalk-ffmpeg), set
+# ecr-role and ecr-region to authenticate Docker to ECR before the build. This uses a
+# read-only IAM role that can only pull images — it cannot push, delete, or modify anything.
 #
 # The image is exported as a Docker tarball, compressed with zstd, and uploaded as a GHA artifact.
 name: Build ECR Image
@@ -45,6 +49,16 @@ on:
         required: false
         type: number
         default: 3
+      ecr-role:
+        description: "AWS IAM role for ECR base image pull (only needed when Dockerfile uses private ECR base images)"
+        required: false
+        type: string
+        default: ""
+      ecr-region:
+        description: "AWS region for ECR login (required when ecr-role is set)"
+        required: false
+        type: string
+        default: "us-east-2"
     secrets:
       ssh-private-key:
         description: "SSH keys for accessing private repositories during build."
@@ -66,6 +80,19 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      # Optional: authenticate to ECR so Docker can pull private base images (e.g. spalk-ffmpeg).
+      # Uses a read-only IAM role scoped to ECR pull permissions only.
+      - name: Configure AWS Credentials for ECR pull
+        if: ${{ inputs.ecr-role != '' }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ inputs.ecr-role }}
+          aws-region: ${{ inputs.ecr-region }}
+
+      - name: Login to ECR for base images
+        if: ${{ inputs.ecr-role != '' }}
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       # Configure deploy SSH keys to download private repos
       # Note, you need to add Repo URL to the key comment so this action knows what to do with it


### PR DESCRIPTION
Adds a shared read-only IAM role (ecr_base_image_pull) that allows
build-ecr-image.yml to pull FFmpeg base images from private ECR repos
during Docker builds. The role is scoped to pull-only permissions on
the FFmpeg ECR repos and trusted from synchroniser, spalk-nginx,
social-media, and vod-processing-service repos.

The build-ecr-image.yml reusable workflow gains optional ecr-role and
ecr-region inputs — when provided, it authenticates to ECR before the
build step.

Also switches spalk-nginx Dockerfile_pr files (nginx + SLS) from
prod_spalk_ffmpeg-static:1.0.0 to dev_spalk_ffmpeg-static:1.7.0 to
align with the synchroniser's pattern of pulling from dev ECR.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- SIBLING_PRS_START -->
## Sibling PRs

- https://github.com/SpalkLtd/content-deleter/pull/8
- https://github.com/SpalkLtd/content-hub/pull/4041
- https://github.com/SpalkLtd/github-reusable-workflows/pull/20
- https://github.com/SpalkLtd/grafana/pull/167
- https://github.com/SpalkLtd/social-media/pull/781
- https://github.com/SpalkLtd/spalk-ffmpeg/pull/80
- https://github.com/SpalkLtd/spalk-janus/pull/64
- https://github.com/SpalkLtd/spalk-live-sync-api/pull/3766
- https://github.com/SpalkLtd/spalk-nginx/pull/603
- https://github.com/SpalkLtd/spalk-stack/pull/542
- https://github.com/SpalkLtd/synchroniser/pull/1694
- https://github.com/SpalkLtd/vod-processing-service/pull/106
<!-- SIBLING_PRS_END -->
