### PR TITLE
Fix testing sheet workflows: JSON-safe command building

### DIFF
--- a/.github/workflows/append-testing-sheet-entry.yml
+++ b/.github/workflows/append-testing-sheet-entry.yml
@@ -51,80 +51,83 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - name: Install pcregrep tool
-      run: |
-        sudo apt-get update
-        sudo apt-get install pcregrep
+    - name: Parse PR and build gsheet commands
+      id: build_commands
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const prTitle = process.env.PR_TITLE;
+          const prDesc = process.env.PR_DESCRIPTION;
+          const repo = process.env.REPO;
+          const prAuthor = process.env.PR_AUTHOR;
+          const prNumber = process.env.PR_NUMBER;
+          const worksheetTitle = process.env.WORKSHEET_TITLE;
 
-    # Finds the ticket number by parsing the the commit string with the regex /(SA-[0-9]*)/ and taking the first match
-    - id: get_data
-      name: get_data
+          const match = (text, regex) => {
+            const m = text.match(regex);
+            return m ? m[1].trim() : '';
+          };
+
+          const ticketNumber = match(prTitle, /(SA-\d+)/);
+          const oldTesterCount = match(prDesc, /Old:\s*(P\d*)/);
+          const newTesterCount = match(prDesc, /New:\s*(P\d*)/);
+          const testInstructions = match(prDesc, /## Instructions([\s\S]*?)## Number of Testers/);
+          const featureFlagName = match(prDesc, /Feature Flag Name:(.*)/);
+          const envVars = match(prDesc, /Has New ENV\/Config\.json Vars:(.*)/);
+          const tfChanges = match(prDesc, /Has TF Changes:(.*)/);
+          const dependentRepo = match(prDesc, /Dependant on Repo:(.*)/);
+
+          core.info(`TICKET_NUMBER=${ticketNumber}`);
+          core.info(`OLD_TESTER_COUNT=${oldTesterCount}`);
+          core.info(`NEW_TESTER_COUNT=${newTesterCount}`);
+          core.info(`TEST_INSTRUCTIONS=${testInstructions}`);
+          core.info(`FEATURE_FLAG_NAME=${featureFlagName}`);
+          core.info(`ENV_VARS=${envVars}`);
+          core.info(`TF_CHANGES=${tfChanges}`);
+          core.info(`DEPENDENT_REPO=${dependentRepo}`);
+
+          // JSON.stringify handles all escaping automatically
+          const commands = JSON.stringify([
+            {
+              command: 'appendData',
+              args: {
+                data: [[
+                  prTitle,
+                  repo,
+                  ticketNumber,
+                  'PR',
+                  '',
+                  '',
+                  oldTesterCount,
+                  newTesterCount,
+                  testInstructions,
+                  prAuthor,
+                  featureFlagName,
+                  envVars,
+                  tfChanges,
+                  dependentRepo,
+                  prNumber
+                ]],
+                worksheetTitle: worksheetTitle,
+                minCol: 1
+              }
+            }
+          ]);
+
+          core.setOutput('commands', commands);
       env:
-        INPUT_PR_DESCRIPTION: ${{ inputs.pr_description }}
-        INPUT_PR_TITLE: ${{ inputs.pr_title }}
-      run: |
-        # Convert line endings
-        PR_DESC="$(echo "$INPUT_PR_DESCRIPTION" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')"
-
-        #Find data out of PR_DESC
-        TICKET_NUMBER=$(echo "$INPUT_PR_TITLE" | pcregrep --only-matching=1 '(SA-[0-9]*)' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        OLD_TESTER_COUNT=$(echo "$PR_DESC" | pcregrep --only-matching=1 'Old: (P[0-9]*)' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        NEW_TESTER_COUNT=$(echo "$PR_DESC" | pcregrep --only-matching=1 'New: (P[0-9]*)' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        TEST_INSTRUCTIONS=$(echo "$PR_DESC" | pcregrep --only-matching=1 --multiline  "(?s)## Instructions(.*)## Number of Testers" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        FEATURE_FLAG_NAME=$(echo "$PR_DESC" | pcregrep --only-matching=1 'Feature Flag Name:(.*?)\\n'  | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        ENV_VARS=$(echo "$PR_DESC" | pcregrep --only-matching=1 'Has New ENV\/Config\.json Vars:(.*?)\\n'  | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        TF_CHANGES=$(echo "$PR_DESC" | pcregrep --only-matching=1 'Has TF Changes:(.*?)\\n' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        DEPENDENT_REPO=$(echo "$PR_DESC" | pcregrep --only-matching=1 'Dependant on Repo:(.*?)\\n'  | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g' || echo '')
-        # store the ticket number in an output
-        echo "TICKET_NUMBER=$TICKET_NUMBER" >> $GITHUB_OUTPUT
-        echo "OLD_TESTER_COUNT=$OLD_TESTER_COUNT" >> $GITHUB_OUTPUT
-        echo "NEW_TESTER_COUNT=$NEW_TESTER_COUNT" >> $GITHUB_OUTPUT
-        echo "TEST_INSTRUCTIONS=$TEST_INSTRUCTIONS" >> $GITHUB_OUTPUT
-        echo "FEATURE_FLAG_NAME=$FEATURE_FLAG_NAME" >> $GITHUB_OUTPUT
-        echo "ENV_VARS=$ENV_VARS" >> $GITHUB_OUTPUT
-        echo "TF_CHANGES=$TF_CHANGES" >> $GITHUB_OUTPUT
-        echo "DEPENDENT_REPO=$DEPENDENT_REPO" >> $GITHUB_OUTPUT
-
-        ## Debug
-        echo "TICKET_NUMBER=$TICKET_NUMBER"
-        echo "OLD_TESTER_COUNT=$OLD_TESTER_COUNT"
-        echo "NEW_TESTER_COUNT=$NEW_TESTER_COUNT"
-        echo "TEST_INSTRUCTIONS=$TEST_INSTRUCTIONS"
-        echo "FEATURE_FLAG_NAME=$FEATURE_FLAG_NAME"
-        echo "ENV_VARS=$ENV_VARS"
-        echo "TF_CHANGES=$TF_CHANGES"
-        echo "DEPENDENT_REPO=$DEPENDENT_REPO"
+        PR_TITLE: ${{ inputs.pr_title }}
+        PR_DESCRIPTION: ${{ inputs.pr_description }}
+        REPO: ${{ inputs.repo }}
+        PR_AUTHOR: ${{ inputs.pr_author }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        WORKSHEET_TITLE: ${{ inputs.worksheet_title }}
 
     - id: insert_row
       uses: SpalkLtd/gsheet.action@v1.2.0
       with:
         spreadsheetId: "${{ secrets.SPREADSHEET_ID }}"
-        commands: |
-            [
-              { "command": "appendData", "args": {
-                "data": [
-                  [
-                    "${{ inputs.pr_title }}",
-                    "${{ inputs.repo }}",
-                    "${{ steps.get_data.outputs.TICKET_NUMBER }}",
-                    "PR",
-                    "",
-                    "",
-                    "${{ steps.get_data.outputs.OLD_TESTER_COUNT }}",
-                    "${{ steps.get_data.outputs.NEW_TESTER_COUNT }}",
-                    "${{ steps.get_data.outputs.TEST_INSTRUCTIONS }}",
-                    "${{ inputs.pr_author }}",
-                    "${{ steps.get_data.outputs.FEATURE_FLAG_NAME }}",
-                    "${{ steps.get_data.outputs.ENV_VARS }}",
-                    "${{ steps.get_data.outputs.TF_CHANGES }}",
-                    "${{ steps.get_data.outputs.DEPENDENT_REPO }}",
-                    "${{ inputs.pr_number }}"
-                  ]
-                ],
-                "worksheetTitle": "${{ inputs.worksheet_title }}",
-                "minCol": 1
-              } }
-            ]
+        commands: ${{ steps.build_commands.outputs.commands }}
       env:
         GSHEET_CLIENT_EMAIL: ${{ secrets.GSHEET_CLIENT_EMAIL }}
         GSHEET_PRIVATE_KEY: ${{ secrets.GSHEET_PRIVATE_KEY }}

--- a/.github/workflows/append-testing-sheet-entry.yml
+++ b/.github/workflows/append-testing-sheet-entry.yml
@@ -86,30 +86,39 @@ jobs:
           core.info(`TF_CHANGES=${tfChanges}`);
           core.info(`DEPENDENT_REPO=${dependentRepo}`);
 
+          // Build a clickable hyperlink for the PR title
+          const prUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/pull/${prNumber}`;
+          const safeTitle = prTitle.replace(/"/g, '""');
+          const prTitleLink = `=HYPERLINK("${prUrl}","${safeTitle}")`;
+
+          // Prefix with ' to prevent USER_ENTERED interpreting values as formulas
+          const t = (v) => `'${v}`;
+
           // JSON.stringify handles all escaping automatically
           const commands = JSON.stringify([
             {
               command: 'appendData',
               args: {
                 data: [[
-                  prTitle,
-                  repo,
-                  ticketNumber,
+                  prTitleLink,
+                  t(repo),
+                  t(ticketNumber),
                   'PR',
                   '',
                   '',
-                  oldTesterCount,
-                  newTesterCount,
-                  testInstructions,
-                  prAuthor,
-                  featureFlagName,
-                  envVars,
-                  tfChanges,
-                  dependentRepo,
-                  prNumber
+                  t(oldTesterCount),
+                  t(newTesterCount),
+                  t(testInstructions),
+                  t(prAuthor),
+                  t(featureFlagName),
+                  t(envVars),
+                  t(tfChanges),
+                  t(dependentRepo),
+                  t(prNumber)
                 ]],
                 worksheetTitle: worksheetTitle,
-                minCol: 1
+                minCol: 1,
+                valueInputOption: 'USER_ENTERED'
               }
             }
           ]);

--- a/.github/workflows/set-requires-testing-status.yml
+++ b/.github/workflows/set-requires-testing-status.yml
@@ -57,37 +57,76 @@ jobs:
         REPO_COLUMN: "B"
         STATUS_COLUMN: "D"
         WORKSHEET_TITLE: "Dev QA"
-    - name: find_matching_row
+    - name: Find matching row or prepare insert
       if: inputs.pr_number != ''
-      id: find_matching_row
+      id: find_or_insert
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const results = JSON.parse(process.env.RESULTS);
+          const repo = process.env.REPO;
+          const prNumber = process.env.PR_NUMBER;
+          const worksheetTitle = process.env.WORKSHEET_TITLE;
+
+          const rawData = results.results[0].result.rawData;
+          const rowIndex = rawData.findIndex(row => row[0] === repo && row[13] === prNumber);
+
+          if (rowIndex >= 0) {
+            // Row found — build an updateData command
+            const rowNumber = rowIndex + 1;
+            core.info(`Found PR #${prNumber} for ${repo} at row ${rowNumber}`);
+            const commands = JSON.stringify([
+              { command: 'updateData', args: { worksheetTitle, range: `D${rowNumber}`, data: [['REQUIRES TESTING']] } }
+            ]);
+            core.setOutput('commands', commands);
+          } else {
+            // Row not found — fetch PR details and build an appendData command
+            core.warning(`PR #${prNumber} for ${repo} not found in sheet. Inserting new row.`);
+            const [owner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
+            let prTitle = '', prAuthor = '', testInstructions = '';
+            let ticketNumber = '', oldTesterCount = '', newTesterCount = '';
+            let featureFlagName = '', envVars = '', tfChanges = '', dependentRepo = '';
+            try {
+              const { data: pr } = await github.rest.pulls.get({ owner, repo: repoName, pull_number: parseInt(prNumber) });
+              prTitle = pr.title || '';
+              prAuthor = pr.user?.login || '';
+              const body = pr.body || '';
+              const match = (text, regex) => { const m = text.match(regex); return m ? m[1].trim() : ''; };
+              ticketNumber = match(prTitle, /(SA-\d+)/);
+              oldTesterCount = match(body, /Old:\s*(P\d*)/);
+              newTesterCount = match(body, /New:\s*(P\d*)/);
+              testInstructions = match(body, /## Instructions([\s\S]*?)## Number of Testers/);
+              featureFlagName = match(body, /Feature Flag Name:(.*)/);
+              envVars = match(body, /Has New ENV\/Config\.json Vars:(.*)/);
+              tfChanges = match(body, /Has TF Changes:(.*)/);
+              dependentRepo = match(body, /Dependant on Repo:(.*)/);
+            } catch (e) {
+              core.warning(`Could not fetch PR details: ${e.message}`);
+            }
+            const commands = JSON.stringify([
+              { command: 'appendData', args: {
+                data: [[ prTitle, repo, ticketNumber, 'REQUIRES TESTING', '', '',
+                         oldTesterCount, newTesterCount, testInstructions, prAuthor,
+                         featureFlagName, envVars, tfChanges, dependentRepo, prNumber ]],
+                worksheetTitle,
+                minCol: 1
+              }}
+            ]);
+            core.setOutput('commands', commands);
+          }
       env:
-          RESULTS: ${{ steps.read_worksheet.outputs.results }}
-          REPO: ${{ inputs.repo }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-      run: |
-        echo "ticket number = $PR_NUMBER"
-        echo "$RESULTS"
-        ROW_NUMBER=$(echo "$RESULTS" | jq -e --arg repo "$REPO" --arg pr "$PR_NUMBER" '.results[0].result.rawData | map(.[0]==$repo and .[13]==$pr) | index(true) | tostring | tonumber + 1')
-        echo "row = $ROW_NUMBER"
-        echo "ROW_NUMBER=$ROW_NUMBER" >> $GITHUB_OUTPUT
+        RESULTS: ${{ steps.read_worksheet.outputs.results }}
+        REPO: ${{ inputs.repo }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        WORKSHEET_TITLE: ${{ inputs.worksheet_title }}
+
     - id: 'update_worksheet'
-      if: inputs.pr_number != ''
-      uses: SpalkLtd/gsheet.action@v1.2.0 # you can specify '@release' to always have the latest changes
+      if: inputs.pr_number != '' && steps.find_or_insert.outputs.commands != ''
+      uses: SpalkLtd/gsheet.action@v1.2.0
       with:
         spreadsheetId: ${{ secrets.SPREADSHEET_ID }}
-        commands: | # list of commands, specified as a valid JSON string
-          [
-            { "command": "updateData",
-            "args": {
-                "worksheetTitle": "$WORKSHEET_TITLE",
-                "range": "${{ env.STATUS_COLUMN }}${{steps.find_matching_row.outputs.ROW_NUMBER }}",
-                "data":[["REQUIRES TESTING"]]
-              }
-            }
-          ]
+        commands: ${{ steps.find_or_insert.outputs.commands }}
       env:
         GSHEET_CLIENT_EMAIL: ${{ secrets.GSHEET_CLIENT_EMAIL }}
         GSHEET_PRIVATE_KEY: ${{ secrets.GSHEET_PRIVATE_KEY }}
-        STATUS_COLUMN: "D"
-        WORKSHEET_TITLE: ${{ inputs.worksheet_title }}
 

--- a/.github/workflows/set-requires-testing-status.yml
+++ b/.github/workflows/set-requires-testing-status.yml
@@ -103,13 +103,19 @@ jobs:
             } catch (e) {
               core.warning(`Could not fetch PR details: ${e.message}`);
             }
+            const prUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/pull/${prNumber}`;
+            const safeTitle = prTitle.replace(/"/g, '""');
+            const prTitleLink = `=HYPERLINK("${prUrl}","${safeTitle}")`;
+            // Prefix with ' to prevent USER_ENTERED interpreting values as formulas
+            const t = (v) => `'${v}`;
             const commands = JSON.stringify([
               { command: 'appendData', args: {
-                data: [[ prTitle, repo, ticketNumber, 'REQUIRES TESTING', '', '',
-                         oldTesterCount, newTesterCount, testInstructions, prAuthor,
-                         featureFlagName, envVars, tfChanges, dependentRepo, prNumber ]],
+                data: [[ prTitleLink, t(repo), t(ticketNumber), 'REQUIRES TESTING', '', '',
+                         t(oldTesterCount), t(newTesterCount), t(testInstructions), t(prAuthor),
+                         t(featureFlagName), t(envVars), t(tfChanges), t(dependentRepo), t(prNumber) ]],
                 worksheetTitle,
-                minCol: 1
+                minCol: 1,
+                valueInputOption: 'USER_ENTERED'
               }}
             ]);
             core.setOutput('commands', commands);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Add `runner` input argument to build-and-deploy-ecr-image.yml
 - Replace deprecated `::set-output` with `$GITHUB_OUTPUT` and upgrade all third-party actions to latest versions (SHA-pinned)
 - Move `${{ }}` expressions out of `run:` blocks into `env:` to prevent shell injection
+- Fix testing sheet workflows to use `actions/github-script` for JSON-safe command building and auto-insert missing rows on merge


### PR DESCRIPTION
## Summary

- Rewrites `append-testing-sheet-entry.yml` and `set-requires-testing-status.yml` to use `actions/github-script` instead of shell-based parsing (`pcregrep`/`sed`/`jq`)
- `JSON.stringify()` handles all escaping automatically, fixing broken JSON when PR descriptions contain double quotes (e.g. `go test -run "TestFoo"`)
- When the merge workflow can't find a matching row in the sheet, it now fetches PR details from the GitHub API and inserts a new row with "REQUIRES TESTING" status instead of crashing

## Test plan

- [ ] Open a test PR with double quotes in the test instructions section and verify the `pr-opened` workflow creates the sheet entry correctly
- [ ] Merge a PR that has no existing sheet row and verify the `set-requires-testing-status` workflow creates the entry with "REQUIRES TESTING" status
- [ ] Merge a PR that has an existing sheet row and verify the status is updated to "REQUIRES TESTING" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)