### PR TITLE
Migrate vod-processing-service to use GHA for build/deploy/activate

### DIFF
--- a/.github/workflows/activate-lambda.yml
+++ b/.github/workflows/activate-lambda.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.1.0
         with:
           role-to-assume: ${{ inputs.aws-role }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/activate-lambda.yml
+++ b/.github/workflows/activate-lambda.yml
@@ -1,0 +1,54 @@
+# This workflow updates a Lambda function's 'current' alias to point to a specific version.
+# It does NOT check out code, does NOT have SSH keys, and does NOT build anything.
+# This is the activation step that makes a deployed Lambda version live.
+#
+# In the IAM trust policy, this workflow is only trusted in dev — prod activation is
+# performed manually via switch-versions.sh by an operator with direct AWS access.
+# This ensures that code write access alone cannot activate production artefacts.
+#
+# It will require setting up correct IAM authorization, which is detailed in README.md.
+name: Activate Lambda
+
+on:
+  workflow_call:
+    inputs:
+      aws-role:
+        description: "AWS IAM role to assume via OIDC"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS region for the Lambda function"
+        required: true
+        type: string
+      function-name:
+        description: "Lambda function name (e.g. dev_vod_processing_http_handler)"
+        required: true
+        type: string
+      target-version:
+        description: "The numeric Lambda version to activate (from deploy-lambda.yml output)"
+        required: true
+        type: string
+
+jobs:
+  activate-lambda:
+    name: Activate Lambda
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Update current alias
+        env:
+          FUNCTION_NAME: ${{ inputs.function-name }}
+          TARGET_VERSION: ${{ inputs.target-version }}
+        run: |
+          echo "Updating 'current' alias to version ${TARGET_VERSION}"
+          aws lambda update-alias \
+            --function-name "$FUNCTION_NAME" \
+            --name current \
+            --function-version "$TARGET_VERSION" \
+            --region ${{ inputs.aws-region }} > /dev/null
+          echo "Activated version ${TARGET_VERSION} as 'current'"

--- a/.github/workflows/build-lambda.yml
+++ b/.github/workflows/build-lambda.yml
@@ -1,0 +1,89 @@
+# This workflow builds a Go Lambda binary and uploads it as a GHA artifact.
+# It does NOT have AWS credentials and cannot deploy or push anything to AWS.
+# The binary is deployed by a separate deploy-lambda.yml workflow.
+#
+# This separation ensures that code execution (go build) never has access
+# to deployment credentials.
+name: Build Lambda
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: "Go version to use for building"
+        required: false
+        type: string
+        default: "1.18"
+      build-dir:
+        description: "Path to the Go package containing main (e.g. ./exec/http/lambda)"
+        required: true
+        type: string
+      binary-name:
+        description: "Output binary name (use 'bootstrap' for provided.al2023 runtime, 'main' for go1.x)"
+        required: false
+        type: string
+        default: "main"
+      artifact-name:
+        description: "Name for the uploaded artifact (must be unique within the workflow run)"
+        required: true
+        type: string
+      runner:
+        description: "The type of runner to use"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+    secrets:
+      ssh-private-key:
+        description: "SSH keys for accessing private Go module repositories."
+        required: false
+    outputs:
+      artifact-name:
+        description: "Name of the uploaded artifact containing the Lambda binary"
+        value: ${{ jobs.build-lambda.outputs.artifact-name }}
+
+jobs:
+  build-lambda:
+    name: Build Lambda
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    env:
+      GOPRIVATE: "github.com/SpalkLtd/*"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          cache: true
+
+      - run: go env -w GOPRIVATE="github.com/SpalkLtd/*"
+
+      # Configure deploy SSH keys to download private repos.
+      # Details: https://github.com/SpalkLtd/ssh-agent#support-for-github-deploy-keys
+      - name: Allow access to Spalk private repositories
+        if: ${{ secrets.ssh-private-key != '' }}
+        uses: SpalkLtd/ssh-agent@26e485b72da53538f103f191ddd325d2f2ef3771
+        with:
+          ssh-private-key: ${{ secrets.ssh-private-key }}
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Build Lambda binary
+        env:
+          GOOS: linux
+          GOARCH: amd64
+          CGO_ENABLED: "0"
+        run: |
+          go build -ldflags="-s -w" -o /tmp/${{ inputs.binary-name }} ${{ inputs.build-dir }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/${{ inputs.binary-name }}
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/build-lambda.yml
+++ b/.github/workflows/build-lambda.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v6.4.0
         with:
           go-version: ${{ inputs.go-version }}
           cache: true
@@ -86,7 +86,7 @@ jobs:
           go build -ldflags="-s -w" -o /tmp/${{ inputs.binary-name }} ${{ inputs.build-dir }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: /tmp/${{ inputs.binary-name }}

--- a/.github/workflows/build-lambda.yml
+++ b/.github/workflows/build-lambda.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      use-ssh:
+        description: "Whether to use SSH for private repositories"
+        required: false
+        type: boolean
+        default: false
     secrets:
       ssh-private-key:
         description: "SSH keys for accessing private Go module repositories."
@@ -69,7 +74,7 @@ jobs:
       # Configure deploy SSH keys to download private repos.
       # Details: https://github.com/SpalkLtd/ssh-agent#support-for-github-deploy-keys
       - name: Allow access to Spalk private repositories
-        if: ${{ secrets.ssh-private-key != '' }}
+        if: ${{ inputs.use-ssh }}
         uses: SpalkLtd/ssh-agent@26e485b72da53538f103f191ddd325d2f2ef3771
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}

--- a/.github/workflows/build-lambda.yml
+++ b/.github/workflows/build-lambda.yml
@@ -27,6 +27,11 @@ on:
         description: "Name for the uploaded artifact (must be unique within the workflow run)"
         required: true
         type: string
+      goarch:
+        description: "Target architecture (amd64 or arm64)"
+        required: false
+        type: string
+        default: "amd64"
       runner:
         description: "The type of runner to use"
         required: false
@@ -75,7 +80,7 @@ jobs:
       - name: Build Lambda binary
         env:
           GOOS: linux
-          GOARCH: amd64
+          GOARCH: ${{ inputs.goarch }}
           CGO_ENABLED: "0"
         run: |
           go build -ldflags="-s -w" -o /tmp/${{ inputs.binary-name }} ${{ inputs.build-dir }}

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -71,13 +71,13 @@ jobs:
           echo "name=${ALIAS}" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.1.0
         with:
           role-to-assume: ${{ inputs.aws-role }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Download binary artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: /tmp/lambda-build

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,0 +1,145 @@
+# This workflow downloads a pre-built Lambda binary artifact and deploys it to AWS Lambda.
+# It does NOT check out caller repo code, does NOT have SSH keys, and does NOT execute
+# any user code. This separation ensures that AWS credentials are never available during
+# code execution.
+#
+# The workflow uploads the binary + config to S3, updates the Lambda function code,
+# publishes a new version, and creates a version-specific alias. It does NOT update
+# the 'current' alias — that is handled by activate-lambda.yml (dev) or manually (prod).
+#
+# It will require setting up correct IAM authorization, which is detailed in README.md.
+name: Deploy Lambda
+
+on:
+  workflow_call:
+    inputs:
+      aws-role:
+        description: "AWS IAM role to assume via OIDC"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS region for deployment"
+        required: true
+        type: string
+      artifact-name:
+        description: "Name of the artifact containing the Lambda binary (from build-lambda.yml)"
+        required: true
+        type: string
+      binary-name:
+        description: "Name of the binary file inside the artifact"
+        required: false
+        type: string
+        default: "main"
+      function-name:
+        description: "Lambda function name (e.g. dev_vod_processing_http_handler)"
+        required: true
+        type: string
+      config-s3-path:
+        description: "S3 URI for the config.json file (e.g. s3://spalk-configs/dev/us-east-2/vod-processing-service/lambda/config.json)"
+        required: true
+        type: string
+      lambda-binaries-bucket:
+        description: "S3 bucket for Lambda deployment ZIPs (e.g. dev-spalk-vod-processing-lambda-binaries)"
+        required: true
+        type: string
+      alias-name:
+        description: "Version-specific alias to create (e.g. sha-abc123 or v1-2-3). Must NOT be 'current'."
+        required: true
+        type: string
+    outputs:
+      version:
+        description: "The published Lambda version number"
+        value: ${{ jobs.deploy-lambda.outputs.version }}
+
+jobs:
+  deploy-lambda:
+    name: Deploy Lambda
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.publish.outputs.version }}
+    steps:
+      - name: Sanitize and validate alias name
+        id: alias
+        run: |
+          # Lambda alias names must match [a-zA-Z0-9-_]. Replace dots with hyphens
+          # (e.g. v1.2.3 → v1-2-3) to support release tags as alias names.
+          ALIAS=$(echo "${{ inputs.alias-name }}" | sed 's/\./-/g')
+          if [[ "$ALIAS" == "current" ]]; then
+            echo "::error::Refusing to create alias 'current'. Use activate-lambda.yml to update the live alias."
+            exit 1
+          fi
+          echo "name=${ALIAS}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/lambda-build
+
+      - name: Download config from S3
+        run: |
+          aws s3 cp "${{ inputs.config-s3-path }}" /tmp/lambda-build/config.json
+
+      - name: Create deployment ZIP
+        run: |
+          cd /tmp/lambda-build
+          chmod +x ${{ inputs.binary-name }}
+          zip -j /tmp/lambda-deploy.zip ${{ inputs.binary-name }} config.json
+
+      - name: Upload ZIP to S3
+        env:
+          BUCKET: ${{ inputs.lambda-binaries-bucket }}
+          ALIAS: ${{ steps.alias.outputs.name }}
+        run: |
+          aws s3 cp /tmp/lambda-deploy.zip "s3://${BUCKET}/lambda_${ALIAS}.zip"
+
+      - name: Update Lambda function code
+        env:
+          FUNCTION_NAME: ${{ inputs.function-name }}
+          BUCKET: ${{ inputs.lambda-binaries-bucket }}
+          ALIAS: ${{ steps.alias.outputs.name }}
+        run: |
+          aws lambda update-function-code \
+            --function-name "$FUNCTION_NAME" \
+            --s3-bucket "$BUCKET" \
+            --s3-key "lambda_${ALIAS}.zip" \
+            --region ${{ inputs.aws-region }} > /dev/null
+
+      - name: Wait for function code update
+        env:
+          FUNCTION_NAME: ${{ inputs.function-name }}
+        run: |
+          aws lambda wait function-updated \
+            --function-name "$FUNCTION_NAME" \
+            --region ${{ inputs.aws-region }}
+
+      - name: Publish new version
+        id: publish
+        env:
+          FUNCTION_NAME: ${{ inputs.function-name }}
+        run: |
+          VERSION=$(aws lambda publish-version \
+            --function-name "$FUNCTION_NAME" \
+            --region ${{ inputs.aws-region }} \
+            --output json | jq -r '.Version')
+          echo "Published Lambda version: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create version-specific alias
+        env:
+          FUNCTION_NAME: ${{ inputs.function-name }}
+          ALIAS: ${{ steps.alias.outputs.name }}
+          VERSION: ${{ steps.publish.outputs.version }}
+        run: |
+          echo "Creating alias '${ALIAS}' pointing to version ${VERSION}"
+          aws lambda create-alias \
+            --function-name "$FUNCTION_NAME" \
+            --name "$ALIAS" \
+            --function-version "$VERSION" \
+            --region ${{ inputs.aws-region }} > /dev/null

--- a/README.md
+++ b/README.md
@@ -1,13 +1,44 @@
 # github-reusable-workflows
 
-Reusuable Github Workflows for Spalk Organisation
+Reusable GitHub Workflows for the Spalk Organisation.
 
-Example of how to use:
+## Workflow families
 
-```
+### ECR workflows (Docker/ECS services)
+
+| Workflow                         | Purpose                                         | AWS Credentials          | Code Checkout |
+| -------------------------------- | ----------------------------------------------- | ------------------------ | ------------- |
+| `build-ecr-image.yml`            | Build Docker image, upload as artifact          | ECR pull only (optional) | Yes           |
+| `push-ecr-image.yml`             | Push artifact to ECR                            | ECR push                 | No            |
+| `create-multi-arch-manifest.yml` | Create multi-arch manifest from per-arch images | ECR push                 | No            |
+| `promote-to-dev.yml`             | Retag image as `:latest` in dev                 | ECR push (dev only)      | No            |
+| `cleanup-ecr-images.yml`         | Delete PR images from ECR                       | ECR delete               | No            |
+
+### Lambda workflows (Go Lambda functions)
+
+| Workflow              | Purpose                                                | AWS Credentials    | Code Checkout |
+| --------------------- | ------------------------------------------------------ | ------------------ | ------------- |
+| `build-lambda.yml`    | Build Go binary, upload as artifact                    | None               | Yes           |
+| `deploy-lambda.yml`   | Deploy binary to Lambda, publish version, create alias | S3 + Lambda deploy | No            |
+| `activate-lambda.yml` | Update `current` alias (dev only)                      | Lambda UpdateAlias | No            |
+
+The Lambda workflows enforce **artefact/activation separation**: `deploy-lambda.yml` can create new Lambda versions but cannot make them live. Only `activate-lambda.yml` can update the `current` alias, and its IAM trust policy is restricted to dev. Production activation is manual. See the [CI/CD Auth & Security docs](../../docs/infra/ci-cd-auth-security.md) for details.
+
+### Other workflows
+
+| Workflow                          | Purpose                                          |
+| --------------------------------- | ------------------------------------------------ |
+| `tagandrelease.yml`               | Create GitHub Release from "cut version" commits |
+| `changedonlychangelog.yml`        | Detect changelog-only PRs to skip CI             |
+| `append-testing-sheet-entry.yml`  | Add PR to QA testing Google Sheet                |
+| `set-requires-testing-status.yml` | Update testing sheet status on merge             |
+
+## Example usage
+
+```yaml
 jobs:
-    tag_and_release:
-        uses: SpalkLtd/github-reusable-workflows/.github/workflows/tagandrelease.yml@main
+  tag_and_release:
+    uses: SpalkLtd/github-reusable-workflows/.github/workflows/tagandrelease.yml@main
 ```
 
 ## Authorising reusable workflows in AWS IAM.
@@ -17,6 +48,7 @@ This will require customising the Github OIDC token to include details about
 what it is going and updating the IAM policy to allow this.
 
 ### Github OIDC Token
+
 You can get details about the OIDC token running this command:
 
 ```bash
@@ -40,17 +72,21 @@ gh api \
     /repos/SpalkLtd/{repo_name}/actions/oidc/customization/sub \
     -F "use_default=false" \
     -f "include_claim_keys[]=repo" \
-    -f "include_claim_keys[]=job_workflow_ref" 
+    -f "include_claim_keys[]=job_workflow_ref"
 ```
 
 This will result in a token that looks like this:
+
 ```
 repo:SpalkLtd/synchroniser:job_workflow_ref:SpalkLtd/github-reusable-workflows/.github/workflows/build-and-deploy-ecr-image.ml@f4cfdf77ca0470aabea01d44d58e11bd954155ce
 ```
+
 ### AWS IAM
+
 Your IAM policy should then be updated to require this sub claim.
 
 For example:
+
 ```hcl
 data "aws_iam_policy_document" "spalk_ffmpeg_github_assume_role_policy_cd" {
 statement {


### PR DESCRIPTION
# Description

Migrates the vod-processing-service **Lambda HTTP handler** build and deploy pipeline from CodeBuild to GitHub Actions, using three new reusable workflows that enforce artefact/activation separation.

The existing Docker/ECR worker pipeline is unchanged. The Lambda pipeline runs in parallel alongside it.

**Is Breaking Change: No**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# What's included

### 3 new reusable workflows (`tooling/ci/github-reusable-workflows/`)

- **`build-lambda.yml`** -- Builds Go binary, uploads as GHA artifact. Has no AWS credentials (mirrors `build-ecr-image.yml` security model).
- **`deploy-lambda.yml`** -- Downloads pre-built binary, packages with config.json from S3, uploads ZIP to S3, updates Lambda function code, publishes a numbered version, creates a version-specific alias. Never checks out caller code. Cannot update the `current` alias.
- **`activate-lambda.yml`** -- Updates the `current` alias to a specific published version. IAM trust policy only permits this in dev; prod activation remains manual via `switch-versions.sh`.

### VOD Processing Service workflow updates

- **`deploy-to-dev.yml`** -- Adds `build-lambda` -> `deploy-lambda` (sha-based alias) -> `activate-lambda` jobs, running in parallel with existing ECR jobs.
- **`release-published.yml`** -- Adds `build-lambda` -> `deploy-lambda` (version tag alias) jobs. No activation step -- prod `current` alias is updated manually.

### Terraform IAM (`github_actions.tf`)

- New IAM role `{stage}_vod_processing_lambda_github_execution_role_cd` with:
  - S3 read for config, S3 read/write for Lambda binaries bucket
  - Lambda deploy permissions (GetFunctionConfiguration, UpdateFunctionCode, PublishVersion, CreateAlias, UpdateAlias, ListAliases)
  - Trust policy: `deploy-lambda.yml` in both stages; `activate-lambda.yml` in dev only
- New locals: `gha_lambda_deploy_workflows`, `gha_lambda_activate_workflows`

### Documentation updates

- `ci-cd-auth-security.md` -- New "Artefact Creation vs Activation Separation" section explaining the security model
- `ci-cd-reusable-workflows.md` -- Reference docs for all three Lambda workflows
- `ci-cd-service-patterns.md` -- Updated VOD Processing section with worker + Lambda pipeline details
- `README.md` (reusable workflows) -- Added Lambda workflow family table, restructured into ECR/Lambda/Other sections

# How Has This Been Tested?

- [x] Local testing
- [ ] Automated tests
- [ ] Manual testing in preprod env

## Instructions

1. Review the Terraform IAM changes to confirm the trust policy correctly restricts `activate-lambda.yml` to dev only
2. After merge, apply Terraform in dev and prod to create the new IAM role
3. Verify a push to master triggers both the ECR and Lambda pipelines in parallel
4. Verify the dev Lambda `current` alias is updated automatically
5. Create a release and verify the prod Lambda version is published but `current` alias is NOT updated

## Number of Testers
Old: P
New: P

Feature Flag Name: N/A
Has New ENV/Config.json Vars: No
Has TF Changes: Yes -- new IAM role for Lambda GitHub Actions OIDC
Dependant on Repo: github-reusable-workflows (subtree, included in this PR)

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have considered the amount of requests and data this will retrieve

<!-- SIBLING_PRS_START -->
## Sibling PRs

- https://github.com/SpalkLtd/github-reusable-workflows/pull/24
- https://github.com/SpalkLtd/spalk-stack/pull/559
- https://github.com/SpalkLtd/vod-processing-service/pull/116
<!-- SIBLING_PRS_END -->
