### PR TITLE
Add cleanup-lambda.yml reusable workflow for PR-scoped Lambda cleanup

### DIFF
--- a/.github/workflows/cleanup-lambda.yml
+++ b/.github/workflows/cleanup-lambda.yml
@@ -1,0 +1,168 @@
+# This workflow cleans up PR-scoped Lambda aliases, their associated published
+# versions, and (optionally) the deployment ZIPs uploaded by `deploy-lambda.yml`.
+#
+# It is intended to run on PR close to tear down per-PR preview deployments
+# created by `deploy-lambda.yml`. It refuses to operate on the protected
+# `current` alias (used for live traffic) or on prefixes that could match
+# release aliases.
+#
+# It will require setting up correct IAM authorization, which is detailed in README.md.
+name: Clean up PR Lambda aliases
+
+on:
+  workflow_call:
+    inputs:
+      aws-role:
+        description: 'AWS IAM role to assume'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS region for the Lambda functions'
+        required: true
+        type: string
+      function-names:
+        description: 'JSON array of Lambda function names (e.g. ["fn-a", "fn-b"])'
+        required: true
+        type: string
+      alias-prefix:
+        description: 'Prefix for aliases to clean up (e.g. "pr-42-"). Must not match "current".'
+        required: true
+        type: string
+      lambda-binaries-bucket:
+        description: 'Optional S3 bucket for deployment ZIPs. When set, deletes lambda_${alias-prefix}*.zip objects. When unset, skips S3 cleanup.'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  cleanup_lambda:
+    name: Clean up PR Lambda aliases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate alias prefix
+        env:
+          PREFIX: ${{ inputs.alias-prefix }}
+        run: |
+          # Guard against empty / trivially unsafe prefixes that would match
+          # too much (including release aliases and the protected `current`).
+          if [[ -z "$PREFIX" || "$PREFIX" == "-" ]]; then
+            echo "::error::alias-prefix must be a non-empty, specific string (e.g. 'pr-42-'). Got: '${PREFIX}'"
+            exit 1
+          fi
+
+          # Refuse prefixes that would match a reserved / release-style alias.
+          PROTECTED_ALIASES=("current" "v" "release")
+          for alias in "${PROTECTED_ALIASES[@]}"; do
+            if [[ "$alias" == "$PREFIX"* ]]; then
+              echo "::error::Refusing to clean up aliases matching reserved alias '${alias}'. alias-prefix '${PREFIX}' would match '${alias}' aliases."
+              exit 1
+            fi
+          done
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ inputs.aws-role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Delete PR aliases and their versions
+        env:
+          FUNCTION_NAMES: ${{ inputs.function-names }}
+          PREFIX: ${{ inputs.alias-prefix }}
+          REGION: ${{ inputs.aws-region }}
+        run: |
+          set -euo pipefail
+
+          echo "Starting Lambda alias cleanup with prefix '${PREFIX}'."
+
+          while IFS= read -r FN; do
+            [[ -z "$FN" ]] && continue
+            echo "Processing function: $FN"
+
+            # Paginate list-aliases using NextMarker. aws-cli will return
+            # NextMarker when results are truncated.
+            NEXT_MARKER=""
+            while : ; do
+              if [[ -z "$NEXT_MARKER" ]]; then
+                PAGE=$(aws lambda list-aliases \
+                  --function-name "$FN" \
+                  --region "$REGION" \
+                  --output json)
+              else
+                PAGE=$(aws lambda list-aliases \
+                  --function-name "$FN" \
+                  --region "$REGION" \
+                  --marker "$NEXT_MARKER" \
+                  --output json)
+              fi
+
+              # Extract matching aliases as TSV lines: "<name>\t<version>"
+              MATCHES=$(echo "$PAGE" | jq -r \
+                --arg prefix "$PREFIX" \
+                '.Aliases[] | select(.Name | startswith($prefix)) | "\(.Name)\t\(.FunctionVersion)"')
+
+              if [[ -n "$MATCHES" ]]; then
+                while IFS=$'\t' read -r ALIAS VERSION; do
+                  [[ -z "$ALIAS" ]] && continue
+                  if [[ "$ALIAS" == "current" ]]; then
+                    # Defence-in-depth: prefix guard should already prevent this.
+                    echo "::error::Refusing to delete protected alias 'current' on function '${FN}'."
+                    exit 1
+                  fi
+
+                  echo "Deleting alias '${ALIAS}' (version ${VERSION}) on ${FN}"
+                  aws lambda delete-alias \
+                    --function-name "$FN" \
+                    --name "$ALIAS" \
+                    --region "$REGION"
+
+                  # delete-function with --qualifier deletes only that numbered
+                  # version, not the function itself. '$LATEST' cannot be deleted.
+                  if [[ -n "$VERSION" && "$VERSION" != "\$LATEST" ]]; then
+                    echo "Deleting version ${VERSION} on ${FN}"
+                    aws lambda delete-function \
+                      --function-name "$FN" \
+                      --qualifier "$VERSION" \
+                      --region "$REGION"
+                  fi
+                done <<< "$MATCHES"
+              fi
+
+              NEXT_MARKER=$(echo "$PAGE" | jq -r '.NextMarker // ""')
+              if [[ -z "$NEXT_MARKER" || "$NEXT_MARKER" == "null" ]]; then
+                break
+              fi
+            done
+          done < <(echo "$FUNCTION_NAMES" | jq -r '.[]')
+
+          echo "Lambda alias cleanup complete."
+
+      - name: Delete PR deployment ZIPs from S3
+        if: inputs.lambda-binaries-bucket != ''
+        env:
+          BUCKET: ${{ inputs.lambda-binaries-bucket }}
+          PREFIX: ${{ inputs.alias-prefix }}
+        run: |
+          set -euo pipefail
+
+          S3_PREFIX="lambda_${PREFIX}"
+          echo "Listing S3 objects in bucket '${BUCKET}' with prefix '${S3_PREFIX}'."
+
+          # Collect all matching .zip keys across pages.
+          KEYS=$(aws s3api list-objects-v2 \
+            --bucket "$BUCKET" \
+            --prefix "$S3_PREFIX" \
+            --query 'Contents[?ends_with(Key, `.zip`)].Key' \
+            --output text)
+
+          if [[ -z "$KEYS" || "$KEYS" == "None" ]]; then
+            echo "No matching ZIP objects found; skipping S3 cleanup."
+            exit 0
+          fi
+
+          for KEY in $KEYS; do
+            echo "Deleting s3://${BUCKET}/${KEY}"
+            aws s3 rm "s3://${BUCKET}/${KEY}"
+          done
+
+          echo "S3 ZIP cleanup complete."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Replace deprecated `::set-output` with `$GITHUB_OUTPUT` and upgrade all third-party actions to latest versions (SHA-pinned)
 - Move `${{ }}` expressions out of `run:` blocks into `env:` to prevent shell injection
 - Fix testing sheet workflows to use `actions/github-script` for JSON-safe command building and auto-insert missing rows on merge
+- Add `cleanup-lambda.yml` reusable workflow for PR-scoped Lambda alias/version/ZIP cleanup.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,22 @@ Reusable GitHub Workflows for the Spalk Organisation.
 
 ### Lambda workflows (Go Lambda functions)
 
-| Workflow              | Purpose                                                | AWS Credentials    | Code Checkout |
-| --------------------- | ------------------------------------------------------ | ------------------ | ------------- |
-| `build-lambda.yml`    | Build Go binary, upload as artifact                    | None               | Yes           |
-| `deploy-lambda.yml`   | Deploy binary to Lambda, publish version, create alias | S3 + Lambda deploy | No            |
-| `activate-lambda.yml` | Update `current` alias (dev only)                      | Lambda UpdateAlias | No            |
+| Workflow              | Purpose                                                | AWS Credentials         | Code Checkout |
+| --------------------- | ------------------------------------------------------ | ----------------------- | ------------- |
+| `build-lambda.yml`    | Build Go binary, upload as artifact                    | None                    | Yes           |
+| `deploy-lambda.yml`   | Deploy binary to Lambda, publish version, create alias | S3 + Lambda deploy      | No            |
+| `activate-lambda.yml` | Update `current` alias (dev only)                      | Lambda UpdateAlias      | No            |
+| `cleanup-lambda.yml`  | Delete PR aliases, their versions, and optional ZIPs   | Lambda delete + S3 (opt.)| No            |
 
 The Lambda workflows enforce **artefact/activation separation**: `deploy-lambda.yml` can create new Lambda versions but cannot make them live. Only `activate-lambda.yml` can update the `current` alias, and its IAM trust policy is restricted to dev. Production activation is manual. See the [CI/CD Auth & Security docs](../../docs/infra/ci-cd-auth-security.md) for details.
+
+`cleanup-lambda.yml` is the Lambda equivalent of `cleanup-ecr-images.yml`: it tears down per-PR Lambda aliases created by `deploy-lambda.yml`. It refuses to operate on the protected `current` alias (or prefixes like `v`/`release` that could match release aliases). Inputs:
+
+- `aws-role` (required) — IAM role to assume via OIDC.
+- `aws-region` (required) — AWS region for the Lambda functions.
+- `function-names` (required) — JSON array of Lambda function names (e.g. `["fn-a", "fn-b"]`).
+- `alias-prefix` (required) — prefix for aliases to delete (e.g. `pr-42-`). Must not match `current`.
+- `lambda-binaries-bucket` (optional) — when set, also deletes `lambda_${alias-prefix}*.zip` objects from this bucket. When unset, no S3 cleanup is performed.
 
 ### Other workflows
 


### PR DESCRIPTION
## Summary
- Adds `cleanup-lambda.yml`, the Lambda equivalent of `cleanup-ecr-images.yml`, for tearing down per-PR deployments created by `deploy-lambda.yml`.
- Deletes matching aliases, their published versions, and (optionally) the `lambda_<prefix>*.zip` objects in a binaries bucket.
- Refuses prefixes that would match the protected `current` alias or release aliases (`v`, `release`).

## Inputs
- `aws-role` (required) — IAM role to assume via OIDC.
- `aws-region` (required) — AWS region for the Lambda functions.
- `function-names` (required) — JSON array of Lambda function names.
- `alias-prefix` (required) — prefix for aliases to delete (e.g. `pr-42-`).
- `lambda-binaries-bucket` (optional) — when set, also deletes matching ZIPs; when unset, skips S3 cleanup entirely.

<!-- SIBLING_PRS_START -->
## Sibling PRs
- https://github.com/SpalkLtd/spalk-stack/pull/560
- https://github.com/SpalkLtd/spalk-live-sync-api/pull/3868
<!-- SIBLING_PRS_END -->

## Test plan
- [ ] Consumed by spalk-live-sync-api CI (sibling PR) to tear down a PR preview deployment.
- [ ] Verify protected-prefix guard rejects `current`, `v`, `release`, empty string, and `-`.
- [ ] Verify S3 cleanup is skipped when `lambda-binaries-bucket` is not provided.