### PR TITLE
Fail loudly when publish-version errors in deploy-lambda.yml

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -123,11 +123,20 @@ jobs:
         id: publish
         env:
           FUNCTION_NAME: ${{ inputs.function-name }}
+        # `set -o pipefail` is required because the assignment below pipes aws → jq.
+        # Without it, an aws error sets only the failed-aws exit code, but the pipe's
+        # exit status comes from jq (which prints `null` and exits 0), leaving VERSION
+        # empty and silently passing the failure on to create-alias.
         run: |
+          set -o pipefail
           VERSION=$(aws lambda publish-version \
             --function-name "$FUNCTION_NAME" \
             --region ${{ inputs.aws-region }} \
             --output json | jq -r '.Version')
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "::error::publish-version returned an empty version. Check the aws error above."
+            exit 1
+          fi
           echo "Published Lambda version: ${VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Move `${{ }}` expressions out of `run:` blocks into `env:` to prevent shell injection
 - Fix testing sheet workflows to use `actions/github-script` for JSON-safe command building and auto-insert missing rows on merge
 - Add `cleanup-lambda.yml` reusable workflow for PR-scoped Lambda alias/version/ZIP cleanup.
+- Harden `deploy-lambda.yml` publish-version step: enable `pipefail` and assert non-empty version so a failed `aws lambda publish-version` no longer silently produces an empty `version` output.


### PR DESCRIPTION
## Summary

The `publish-version` step in `deploy-lambda.yml` silently swallowed `aws lambda publish-version` failures. Demonstrated on PR-3873's PR Lambda preview build:

```
Error: aws: [ERROR]: An error occurred (ResourceConflictException) ...
Published Lambda version:        ← empty
...
Creating alias 'pr-3873-...' pointing to version
Error: ParamValidation: Invalid length for parameter FunctionVersion, value: 0
```

The actual root cause (a race between two concurrent deploys hitting the same shared dev function) was hidden behind a misleading parameter-validation error in a downstream step. Failure run: https://github.com/SpalkLtd/spalk-live-sync-api/actions/runs/25022483949/job/73286178211?pr=3873

The race itself is being fixed on the caller side (per-function concurrency group in `spalk-live-sync-api`'s `trigger-ci-pr.yml` — sibling PR). This change is the secondary improvement: make future similar failures legible.

- Add `set -o pipefail` so `aws ... | jq` propagates the aws exit code
- Assert `VERSION` is non-empty / non-`null` after the assignment, fail with a clear `::error::` message if not

## Test plan

- [ ] Wait for a downstream caller to run end-to-end on a normal deploy — version still publishes and alias still gets created (no behavioural change in the happy path)
- [ ] If a real conflict happens, the failure now surfaces at the publish-version step with a clear message instead of at create-alias as parameter validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)