### PR TITLE
deploy-lambda: optional moving alias; cleanup: tolerate shared versions

### DIFF
--- a/.github/workflows/cleanup-lambda.yml
+++ b/.github/workflows/cleanup-lambda.yml
@@ -79,8 +79,16 @@ jobs:
             [[ -z "$FN" ]] && continue
             echo "Processing function: $FN"
 
-            # Paginate list-aliases using NextMarker. aws-cli will return
-            # NextMarker when results are truncated.
+            # Versions referenced by matching aliases, collected in pass 1 and
+            # deleted in pass 2. A moving alias (e.g. pr-42-head) and a
+            # version-specific alias (pr-42-<sha>) can point at the SAME version,
+            # and Lambda refuses to delete a version while any alias still
+            # references it. So delete ALL matching aliases first, then delete
+            # the now-dereferenced versions once each.
+            VERSIONS=""
+
+            # Pass 1: delete matching aliases. Paginate list-aliases using
+            # NextMarker; aws-cli returns NextMarker when results are truncated.
             NEXT_MARKER=""
             while : ; do
               if [[ -z "$NEXT_MARKER" ]]; then
@@ -116,14 +124,8 @@ jobs:
                     --name "$ALIAS" \
                     --region "$REGION"
 
-                  # delete-function with --qualifier deletes only that numbered
-                  # version, not the function itself. '$LATEST' cannot be deleted.
                   if [[ -n "$VERSION" && "$VERSION" != "\$LATEST" ]]; then
-                    echo "Deleting version ${VERSION} on ${FN}"
-                    aws lambda delete-function \
-                      --function-name "$FN" \
-                      --qualifier "$VERSION" \
-                      --region "$REGION"
+                    VERSIONS="${VERSIONS}${VERSION}"$'\n'
                   fi
                 done <<< "$MATCHES"
               fi
@@ -133,6 +135,29 @@ jobs:
                 break
               fi
             done
+
+            # Pass 2: delete each distinct version once. delete-function with
+            # --qualifier deletes only that numbered version, not the function.
+            # Process substitution (not a pipe) keeps this loop in the current
+            # shell so a genuine failure still aborts the job.
+            while IFS= read -r VERSION; do
+              [[ -z "$VERSION" ]] && continue
+              echo "Deleting version ${VERSION} on ${FN}"
+              if ! aws lambda delete-function \
+                --function-name "$FN" \
+                --qualifier "$VERSION" \
+                --region "$REGION" 2>/tmp/cleanup_del_err; then
+                if grep -q "ResourceNotFoundException" /tmp/cleanup_del_err; then
+                  echo "Version ${VERSION} already deleted; skipping."
+                elif grep -q "ResourceConflictException" /tmp/cleanup_del_err; then
+                  # Still referenced by a non-matching alias we must not touch.
+                  echo "::warning::Version ${VERSION} on ${FN} still has an alias; leaving in place."
+                else
+                  cat /tmp/cleanup_del_err >&2
+                  exit 1
+                fi
+              fi
+            done < <(echo "$VERSIONS" | sort -u)
           done < <(echo "$FUNCTION_NAMES" | jq -r '.[]')
 
           echo "Lambda alias cleanup complete."

--- a/.github/workflows/cleanup-lambda.yml
+++ b/.github/workflows/cleanup-lambda.yml
@@ -143,20 +143,27 @@ jobs:
             while IFS= read -r VERSION; do
               [[ -z "$VERSION" ]] && continue
               echo "Deleting version ${VERSION} on ${FN}"
+              # Per-iteration stderr capture so the error classification below
+              # only ever sees output from the current invocation (a reused
+              # file could otherwise leak stale stderr into the grep checks).
+              DEL_ERR=$(mktemp)
               if ! aws lambda delete-function \
                 --function-name "$FN" \
                 --qualifier "$VERSION" \
-                --region "$REGION" 2>/tmp/cleanup_del_err; then
-                if grep -q "ResourceNotFoundException" /tmp/cleanup_del_err; then
+                --region "$REGION" 2>"$DEL_ERR"; then
+                if grep -q "ResourceNotFoundException" "$DEL_ERR"; then
                   echo "Version ${VERSION} already deleted; skipping."
-                elif grep -q "ResourceConflictException" /tmp/cleanup_del_err; then
-                  # Still referenced by a non-matching alias we must not touch.
-                  echo "::warning::Version ${VERSION} on ${FN} still has an alias; leaving in place."
+                elif grep -q "ResourceConflictException" "$DEL_ERR"; then
+                  # Still in use (e.g. by an alias or event-source mapping);
+                  # leaving it in place.
+                  echo "::warning::Version ${VERSION} on ${FN} is still in use (e.g. by an alias or event-source mapping); leaving it in place."
                 else
-                  cat /tmp/cleanup_del_err >&2
+                  cat "$DEL_ERR" >&2
+                  rm -f "$DEL_ERR"
                   exit 1
                 fi
               fi
+              rm -f "$DEL_ERR"
             done < <(echo "$VERSIONS" | sort -u)
           done < <(echo "$FUNCTION_NAMES" | jq -r '.[]')
 

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -49,7 +49,7 @@ on:
         required: true
         type: string
       moving-alias-name:
-        description: "Optional moving alias to create-or-update to point at the just-published version (e.g. pr-42-head). Unlike alias-name it may already exist and is re-pointed. Must NOT be 'current'."
+        description: "Optional moving alias to create-or-update to point at the just-published version (e.g. pr-42-head). Unlike alias-name it may already exist and is re-pointed. NOTE: this re-points whatever alias name is passed, so scope it carefully (e.g. per-PR) to limit blast radius. Must NOT be 'current'."
         required: false
         type: string
         default: ""
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Sanitize and validate alias name
         id: alias
+        env:
+          MOVING_ALIAS_NAME: ${{ inputs.moving-alias-name }}
         run: |
           # Lambda alias names must match [a-zA-Z0-9-_]. Replace dots with hyphens
           # (e.g. v1.2.3 → v1-2-3) to support release tags as alias names.
@@ -78,7 +80,7 @@ jobs:
           echo "name=${ALIAS}" >> "$GITHUB_OUTPUT"
 
           # Optional moving alias (e.g. pr-42-head): create-or-updated below.
-          MOVING=$(echo "${{ inputs.moving-alias-name }}" | sed 's/\./-/g')
+          MOVING=$(echo "$MOVING_ALIAS_NAME" | sed 's/\./-/g')
           if [[ "$MOVING" == "current" ]]; then
             echo "::error::Refusing to use moving alias 'current'. Use activate-lambda.yml to update the live alias."
             exit 1
@@ -171,13 +173,27 @@ jobs:
           VERSION: ${{ steps.publish.outputs.version }}
         run: |
           echo "Pointing moving alias '${MOVING}' at version ${VERSION}"
-          aws lambda update-alias \
+          # Capture update-alias stderr so a real failure (throttle, permissions)
+          # is not silently swallowed: only fall back to create-alias when the
+          # alias genuinely does not exist yet. Mirrors cleanup pass-2's
+          # ResourceNotFoundException handling.
+          UPD_ERR=$(mktemp)
+          if ! aws lambda update-alias \
             --function-name "$FUNCTION_NAME" \
             --name "$MOVING" \
             --function-version "$VERSION" \
-            --region ${{ inputs.aws-region }} > /dev/null 2>&1 \
-          || aws lambda create-alias \
-            --function-name "$FUNCTION_NAME" \
-            --name "$MOVING" \
-            --function-version "$VERSION" \
-            --region ${{ inputs.aws-region }} > /dev/null
+            --region ${{ inputs.aws-region }} > /dev/null 2>"$UPD_ERR"; then
+            if grep -q "ResourceNotFoundException" "$UPD_ERR"; then
+              echo "Moving alias '${MOVING}' does not exist yet; creating it."
+              aws lambda create-alias \
+                --function-name "$FUNCTION_NAME" \
+                --name "$MOVING" \
+                --function-version "$VERSION" \
+                --region ${{ inputs.aws-region }} > /dev/null
+            else
+              cat "$UPD_ERR" >&2
+              rm -f "$UPD_ERR"
+              exit 1
+            fi
+          fi
+          rm -f "$UPD_ERR"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -4,8 +4,10 @@
 # code execution.
 #
 # The workflow uploads the binary + config to S3, updates the Lambda function code,
-# publishes a new version, and creates a version-specific alias. It does NOT update
-# the 'current' alias — that is handled by activate-lambda.yml (dev) or manually (prod).
+# publishes a new version, and creates a version-specific alias. It can also
+# create-or-update an optional moving alias (e.g. pr-42-head) pointing at that
+# version. It does NOT update the 'current' alias — that is handled by
+# activate-lambda.yml (dev) or manually (prod).
 #
 # It will require setting up correct IAM authorization, which is detailed in README.md.
 name: Deploy Lambda
@@ -46,6 +48,11 @@ on:
         description: "Version-specific alias to create (e.g. sha-abc123 or v1-2-3). Must NOT be 'current'."
         required: true
         type: string
+      moving-alias-name:
+        description: "Optional moving alias to create-or-update to point at the just-published version (e.g. pr-42-head). Unlike alias-name it may already exist and is re-pointed. Must NOT be 'current'."
+        required: false
+        type: string
+        default: ""
     outputs:
       version:
         description: "The published Lambda version number"
@@ -69,6 +76,14 @@ jobs:
             exit 1
           fi
           echo "name=${ALIAS}" >> "$GITHUB_OUTPUT"
+
+          # Optional moving alias (e.g. pr-42-head): create-or-updated below.
+          MOVING=$(echo "${{ inputs.moving-alias-name }}" | sed 's/\./-/g')
+          if [[ "$MOVING" == "current" ]]; then
+            echo "::error::Refusing to use moving alias 'current'. Use activate-lambda.yml to update the live alias."
+            exit 1
+          fi
+          echo "moving_name=${MOVING}" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.1.0
@@ -141,5 +156,28 @@ jobs:
           aws lambda create-alias \
             --function-name "$FUNCTION_NAME" \
             --name "$ALIAS" \
+            --function-version "$VERSION" \
+            --region ${{ inputs.aws-region }} > /dev/null
+
+      # A moving alias (e.g. pr-42-head) is re-pointed on every deploy, so it may
+      # already exist. update-alias fails on the first deploy (alias absent), so
+      # fall back to create-alias. Kept inside this credentialed, pinned workflow
+      # so the IAM trust policy can be scoped to this workflow ref.
+      - name: Create or update moving alias
+        if: inputs.moving-alias-name != ''
+        env:
+          FUNCTION_NAME: ${{ inputs.function-name }}
+          MOVING: ${{ steps.alias.outputs.moving_name }}
+          VERSION: ${{ steps.publish.outputs.version }}
+        run: |
+          echo "Pointing moving alias '${MOVING}' at version ${VERSION}"
+          aws lambda update-alias \
+            --function-name "$FUNCTION_NAME" \
+            --name "$MOVING" \
+            --function-version "$VERSION" \
+            --region ${{ inputs.aws-region }} > /dev/null 2>&1 \
+          || aws lambda create-alias \
+            --function-name "$FUNCTION_NAME" \
+            --name "$MOVING" \
             --function-version "$VERSION" \
             --region ${{ inputs.aws-region }} > /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@
 - Move `${{ }}` expressions out of `run:` blocks into `env:` to prevent shell injection
 - Fix testing sheet workflows to use `actions/github-script` for JSON-safe command building and auto-insert missing rows on merge
 - Add `cleanup-lambda.yml` reusable workflow for PR-scoped Lambda alias/version/ZIP cleanup.
+- Add optional `moving-alias-name` input to `deploy-lambda.yml` to create-or-update a re-pointable alias (e.g. `pr-42-head`) pointing at the just-published version.
+- Update `cleanup-lambda.yml` to delete aliases before versions and tolerate versions shared by multiple aliases.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Reusable GitHub Workflows for the Spalk Organisation.
 | Workflow              | Purpose                                                | AWS Credentials         | Code Checkout |
 | --------------------- | ------------------------------------------------------ | ----------------------- | ------------- |
 | `build-lambda.yml`    | Build Go binary, upload as artifact                    | None                    | Yes           |
-| `deploy-lambda.yml`   | Deploy binary to Lambda, publish version, create alias | S3 + Lambda deploy      | No            |
+| `deploy-lambda.yml`   | Deploy binary to Lambda, publish version, create alias (and optionally re-point a moving alias via `moving-alias-name`) | S3 + Lambda deploy      | No            |
 | `activate-lambda.yml` | Update `current` alias (dev only)                      | Lambda UpdateAlias      | No            |
 | `cleanup-lambda.yml`  | Delete PR aliases, their versions, and optional ZIPs   | Lambda delete + S3 (opt.)| No            |
 


### PR DESCRIPTION
## What

Adds the building blocks for per-PR Lambda **preview pairing** — letting a PR-version frontend be tested against the matching PR-version backend without moving the live `current` alias. Two reusable workflows change:

### `deploy-lambda.yml` — optional moving alias
- New optional `moving-alias-name` input. When set, the workflow **create-or-updates** that alias to point at the just-published version (e.g. `pr-42-head`), in addition to the existing immutable `alias-name`.
- `update-alias` falls back to `create-alias` on the first deploy. Validated/sanitised like `alias-name`; refuses `current`.
- No-op when the input is omitted, so existing callers are unaffected.
- Kept inside this credentialed, pinned workflow on purpose, so the IAM trust policy can be scoped to this workflow ref rather than handing alias-write to caller repos.

### `cleanup-lambda.yml` — tolerate shared versions
- Now deletes **all** matching aliases first, then deletes the distinct versions once each.
- A moving alias (`pr-42-head`) and a version-specific alias (`pr-42-<sha>`) can point at the **same** version, and Lambda refuses to delete a version while any alias still references it. The old single-pass logic tripped on this.
- Tolerates `ResourceConflictException` (still referenced — leaves it) and `ResourceNotFoundException` (already gone). This is also a latent-correctness fix independent of moving aliases.

## Testing

`bash -n` on both rewritten scripts; functional stub test of the cleanup pass (3 aliases over 2 versions → dedups, deletes each version once; `ResourceConflict` tolerated without aborting).

## Related PRs

Part of a three-PR change for `?api-alias` preview routing:

- **spalk-live-sync-api** — https://github.com/SpalkLtd/spalk-live-sync-api/pull/3991 — the live handler forwards `?api-alias=pr-<n>-head` requests to the matching PR-preview Lambda alias.
- **content-hub** — https://github.com/SpalkLtd/content-hub/pull/4345 — the frontend forwards `?api-alias=` onto API requests.

## Follow-up

After this merges: in spalk-live-sync-api, bump the three reusable pins to this PR's merge SHA and add `moving-alias-name: "pr-${{ github.event.pull_request.number }}-head"` to both deploy jobs. Plus IAM: `lambda:UpdateAlias` on the `_cd` role and `lambda:InvokeFunction` (self-invoke) on the dev function's execution role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
