### PR TITLE
Add monorepo parameterisation inputs (additive, default-preserving)

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -22,6 +22,11 @@ on:
         description: "The Dockerfile to build"
         required: true
         type: string
+      context:
+        description: "Docker build context directory, relative to the repository root (e.g. apps/media/synchroniser for a monorepo caller). The SSH/gitconfig scaffold (docker/gitconfig, docker/ssh) resolves under this directory too. Note: `dockerfile` stays repository-root-relative. Default '.' preserves the standalone-repo behaviour."
+        required: false
+        type: string
+        default: "."
       artifact-name:
         description: "Name for the uploaded artifact (must be unique within the workflow run)"
         required: true
@@ -109,18 +114,25 @@ jobs:
       # This action copies the ~/.gitconfig and ~/.ssh files from the host, that were configured by the previous SpalkLtd/ssh-agent
       # step to correctly access github. It corrects the paths. We are not copying actual private keys, they are held in-memory at all
       # times by the ssh-agent, and crypto functions are done over the env.SSH_AUTH_SOCK socket.
+      # The docker/gitconfig + docker/ssh scaffold lives inside the build context
+      # (the service directory in a monorepo), because the Dockerfile COPYs it with
+      # context-relative paths. mkdir -p keeps this deterministic when a repo ships
+      # the directories empty (git does not track empty dirs).
       - name: Collect Git and SSH config files
         if: ${{ inputs.use-ssh }}
+        env:
+          BUILD_CONTEXT: ${{ inputs.context }}
         run: |
-          cp -f ~/.gitconfig docker/gitconfig/gitconfig
-          cp -r ~/.ssh/* docker/ssh
-          sed 's|/home/runner|/root|g' -i.bak docker/ssh/config
+          mkdir -p "$BUILD_CONTEXT/docker/gitconfig" "$BUILD_CONTEXT/docker/ssh"
+          cp -f ~/.gitconfig "$BUILD_CONTEXT/docker/gitconfig/gitconfig"
+          cp -r ~/.ssh/* "$BUILD_CONTEXT/docker/ssh"
+          sed 's|/home/runner|/root|g' -i.bak "$BUILD_CONTEXT/docker/ssh/config"
 
       - name: Build docker image to tarball
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           ssh: ${{ inputs.use-ssh && secrets.ssh-private-key != '' && format('default={0}', env.SSH_AUTH_SOCK) || '' }}
-          context: .
+          context: ${{ inputs.context }}
           build-args: ${{ inputs.build-args }}
           push: false
           tags: image:${{ inputs.tag }}

--- a/.github/workflows/build-lambda.yml
+++ b/.github/workflows/build-lambda.yml
@@ -15,9 +15,14 @@ on:
         type: string
         default: "1.18"
       build-dir:
-        description: "Path to the Go package containing main (e.g. ./exec/http/lambda)"
+        description: "Path to the Go package containing main, relative to working-directory (e.g. ./exec/http/lambda)"
         required: true
         type: string
+      working-directory:
+        description: "Directory containing the service Go module (its go.mod/go.sum), relative to the repository root (e.g. apps/api/spalk-live-sync-api for a monorepo caller). go mod download and go build run here, and build-dir resolves relative to it. Default '.' preserves the standalone-repo behaviour."
+        required: false
+        type: string
+        default: "."
       binary-name:
         description: "Output binary name (use 'bootstrap' for provided.al2023 runtime, 'main' for go1.x)"
         required: false
@@ -68,6 +73,9 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
           cache: true
+          # Key the module cache on the service go.sum (with the default '.' this is
+          # ./go.sum — unchanged for standalone callers).
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
 
       - run: go env -w GOPRIVATE="github.com/SpalkLtd/*"
 
@@ -80,9 +88,11 @@ jobs:
           ssh-private-key: ${{ secrets.ssh-private-key }}
 
       - name: Download Go modules
+        working-directory: ${{ inputs.working-directory }}
         run: go mod download
 
       - name: Build Lambda binary
+        working-directory: ${{ inputs.working-directory }}
         env:
           GOOS: linux
           GOARCH: ${{ inputs.goarch }}

--- a/.github/workflows/changedonlychangelog.yml
+++ b/.github/workflows/changedonlychangelog.yml
@@ -10,13 +10,18 @@ on:
                 description: 'Github pr number'
                 required: true
                 type: string
+            changelog_path:
+                description: 'Path of the changelog file that counts as "changelog only", relative to the repository root (e.g. apps/media/synchroniser/CHANGELOG.md for a monorepo caller). Default preserves the standalone-repo behaviour.'
+                required: false
+                type: string
+                default: 'CHANGELOG.md'
         secrets:
             githubToken:
                 description: 'Github token passed from the caller workflow'
                 required: true
         outputs:
             changelog_only:
-                description: "True iff CHANGELOG.md was the only file that changed for the PR"
+                description: "True iff the changelog (inputs.changelog_path) was the only file that changed for the PR"
                 value: ${{ jobs.check_changelog.outputs.changelog_only }}
 
 jobs:
@@ -42,4 +47,5 @@ jobs:
         id: set_output
         env:
           FILE_LIST: ${{ steps.get_file_data.outputs.file_list }}
-        run: '[[ "$FILE_LIST" == "CHANGELOG.md" ]] && echo "changelog_only=true" >> $GITHUB_OUTPUT || echo "changelog_only=false" >> $GITHUB_OUTPUT'
+          CHANGELOG_PATH: ${{ inputs.changelog_path }}
+        run: '[[ "$FILE_LIST" == "$CHANGELOG_PATH" ]] && echo "changelog_only=true" >> $GITHUB_OUTPUT || echo "changelog_only=false" >> $GITHUB_OUTPUT'

--- a/.github/workflows/tagandrelease.yml
+++ b/.github/workflows/tagandrelease.yml
@@ -1,6 +1,12 @@
 name: Tag and Release
 on:
     workflow_call:
+        inputs:
+            prefix:
+                description: 'Optional tag namespace, INCLUDING the trailing separator (e.g. "synchroniser/"). When set: only commits whose subject starts with "cut version <prefix>" release (so one cut commit releases exactly one service), the version keeps its original case, the created tag is the full "<prefix>vX.Y.Z" string, and release notes are scoped to the latest existing "<prefix>*" tag. Unset (default) keeps the historical repo-global behaviour byte-identical.'
+                required: false
+                type: string
+                default: ''
         secrets:
             githubToken:
                 description: 'Github token passed from the caller workflow'
@@ -25,23 +31,99 @@ jobs:
               id: get-version
               env:
                   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+                  TAG_PREFIX: ${{ inputs.prefix }}
               run: |
-                  GITHUB_PR_TITLE="$COMMIT_MESSAGE"
-                  GITHUB_PR_TITLE="${GITHUB_PR_TITLE^^}"
-                  GITHUB_PR_TITLE="${GITHUB_PR_TITLE#"CUT VERSION "}"
-                  GITHUB_PR_TAG="${GITHUB_PR_TITLE%% *}"
-                  echo "version=$GITHUB_PR_TAG" >> $GITHUB_OUTPUT
-            - name: Create Release
+                  if [ -z "$TAG_PREFIX" ]; then
+                      # Bare mode (no prefix): historical behaviour, unchanged.
+                      GITHUB_PR_TITLE="$COMMIT_MESSAGE"
+                      GITHUB_PR_TITLE="${GITHUB_PR_TITLE^^}"
+                      GITHUB_PR_TITLE="${GITHUB_PR_TITLE#"CUT VERSION "}"
+                      GITHUB_PR_TAG="${GITHUB_PR_TITLE%% *}"
+                      echo "version=$GITHUB_PR_TAG" >> $GITHUB_OUTPUT
+                      echo "matched=true" >> $GITHUB_OUTPUT
+                  else
+                      # Namespaced mode: the subject must name THIS caller's prefix
+                      # ("cut version <prefix>vX.Y.Z"), and case is PRESERVED —
+                      # uppercasing would mangle the tag ("SYNCHRONISER/V1.2.3").
+                      SUBJECT="${COMMIT_MESSAGE%%$'\n'*}"
+                      case "$SUBJECT" in
+                          "cut version ${TAG_PREFIX}"*)
+                              VERSION="${SUBJECT#cut version }"
+                              VERSION="${VERSION%% *}"
+                              echo "version=$VERSION" >> $GITHUB_OUTPUT
+                              echo "matched=true" >> $GITHUB_OUTPUT
+                              ;;
+                          *)
+                              # Another service's cut (or a malformed subject): skip
+                              # cleanly instead of creating a colliding bare tag.
+                              echo "Commit subject does not start with 'cut version ${TAG_PREFIX}' - not this service's cut, skipping."
+                              echo "version=" >> $GITHUB_OUTPUT
+                              echo "matched=false" >> $GITHUB_OUTPUT
+                              ;;
+                      esac
+                  fi
+            # Namespaced releases scope their generated notes to this service's
+            # previous tag; otherwise the notes would list every other service's
+            # commits since the last org-wide release.
+            - name: Find previous tag for scoped release notes
+              id: previous-tag
+              if: ${{ inputs.prefix != '' && steps.get-version.outputs.matched == 'true' }}
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
+                  TAG_PREFIX: ${{ inputs.prefix }}
                   VERSION: ${{ steps.get-version.outputs.version }}
               with:
                   github-token: ${{ secrets.githubToken }}
                   script: |
-                      github.rest.repos.createRelease({
+                      const prefix = process.env.TAG_PREFIX;
+                      const tags = await github.paginate(github.rest.repos.listTags, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        per_page: 100,
+                      });
+                      const semverKey = (name) => {
+                        const m = name.slice(prefix.length).replace(/^[vV]/, '').match(/^(\d+)\.(\d+)\.(\d+)/);
+                        return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+                      };
+                      const candidates = tags
+                        .map((t) => t.name)
+                        .filter((n) => n.startsWith(prefix) && n !== process.env.VERSION)
+                        .map((n) => ({ name: n, key: semverKey(n) }))
+                        .filter((t) => t.key !== null)
+                        .sort((a, b) => a.key[0] - b.key[0] || a.key[1] - b.key[1] || a.key[2] - b.key[2]);
+                      const previous = candidates.length ? candidates[candidates.length - 1].name : '';
+                      core.setOutput('previous_tag', previous);
+                      core.info(previous
+                        ? `Release notes scoped from previous tag ${previous}`
+                        : `No previous '${prefix}' tag found - first namespaced release gets unscoped notes.`);
+            - name: Create Release
+              if: ${{ steps.get-version.outputs.matched == 'true' }}
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  VERSION: ${{ steps.get-version.outputs.version }}
+                  PREVIOUS_TAG: ${{ steps.previous-tag.outputs.previous_tag }}
+              with:
+                  github-token: ${{ secrets.githubToken }}
+                  script: |
+                      const params = {
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         tag_name: process.env.VERSION,
                         generate_release_notes: true,
                         name: `Release - ${process.env.VERSION}`
-                      })
+                      };
+                      if (process.env.PREVIOUS_TAG) {
+                        // createRelease has no previous_tag_name param, so generate
+                        // the scoped notes explicitly and pass them as the body.
+                        const notes = await github.rest.repos.generateReleaseNotes({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          tag_name: process.env.VERSION,
+                          target_commitish: context.sha,
+                          previous_tag_name: process.env.PREVIOUS_TAG,
+                        });
+                        params.body = notes.data.body;
+                        params.generate_release_notes = false;
+                        params.target_commitish = context.sha;
+                      }
+                      await github.rest.repos.createRelease(params)


### PR DESCRIPTION
Grows the four reusable workflows called by the incoming SpalkLtd/bifrost monorepo with monorepo-aware inputs. Every input is optional and defaults to today's standalone behaviour, so existing per-repo callers are byte-identical:

- build-ecr-image: `context` input (docker build context + SSH/gitconfig scaffold root; dockerfile stays repo-root-relative).
- build-lambda: `working-directory` input (go mod download / go build / build-dir / setup-go cache-dependency-path).
- tagandrelease: `prefix` input for namespaced per-service tags — subject-gated ("cut version <prefix>vX.Y.Z"), case-preserved, scoped release notes; bare mode unchanged.
- changedonlychangelog: `changelog_path` input (default CHANGELOG.md).

Go builds intentionally honour a monorepo-root go.work when present, so deps hoist to the current monorepo src even while per-service go.mod still pin SHAs (GOWORK is left unset — no forced `off`). Builds differ from the per-repo pins by design.

Fixes F02/F03/F39 from the monorepo migration plan. Callers in bifrost pin this commit's SHA and pass the new inputs; that pin bump + the OIDC job_workflow_ref trust rotation happen at cutover (not here).