### PR TITLE
tagandrelease: match cut-version lines anywhere in the message (multi-service cuts)

### DIFF
--- a/.github/workflows/tagandrelease.yml
+++ b/.github/workflows/tagandrelease.yml
@@ -3,7 +3,7 @@ on:
     workflow_call:
         inputs:
             prefix:
-                description: 'Optional tag namespace, INCLUDING the trailing separator (e.g. "synchroniser/"). When set: only commits whose subject starts with "cut version <prefix>" release (so one cut commit releases exactly one service), the version keeps its original case, the created tag is the full "<prefix>vX.Y.Z" string, and release notes are scoped to the latest existing "<prefix>*" tag. Unset (default) keeps the historical repo-global behaviour byte-identical.'
+                description: 'Optional tag namespace, INCLUDING the trailing separator (e.g. "synchroniser/"). When set: the first message line (subject, or a "* "-bulleted squash-body line) starting with "cut version <prefix>" releases — so one squash-merged PR carrying one "cut version <service>/<version>" commit per service can cut several services, each caller matching only its own line. The version keeps its original case, the created tag is the full "<prefix>vX.Y.Z" string, and release notes are scoped to the latest existing "<prefix>*" tag. Unset (default) keeps the historical repo-global behaviour byte-identical.'
                 required: false
                 type: string
                 default: ''
@@ -42,25 +42,36 @@ jobs:
                       echo "version=$GITHUB_PR_TAG" >> $GITHUB_OUTPUT
                       echo "matched=true" >> $GITHUB_OUTPUT
                   else
-                      # Namespaced mode: the subject must name THIS caller's prefix
+                      # Namespaced mode: some line must name THIS caller's prefix
                       # ("cut version <prefix>vX.Y.Z"), and case is PRESERVED —
                       # uppercasing would mangle the tag ("SYNCHRONISER/V1.2.3").
-                      SUBJECT="${COMMIT_MESSAGE%%$'\n'*}"
-                      case "$SUBJECT" in
-                          "cut version ${TAG_PREFIX}"*)
-                              VERSION="${SUBJECT#cut version }"
-                              VERSION="${VERSION%% *}"
-                              echo "version=$VERSION" >> $GITHUB_OUTPUT
-                              echo "matched=true" >> $GITHUB_OUTPUT
-                              ;;
-                          *)
-                              # Another service's cut (or a malformed subject): skip
-                              # cleanly instead of creating a colliding bare tag.
-                              echo "Commit subject does not start with 'cut version ${TAG_PREFIX}' - not this service's cut, skipping."
-                              echo "version=" >> $GITHUB_OUTPUT
-                              echo "matched=false" >> $GITHUB_OUTPUT
-                              ;;
-                      esac
+                      # Squash-merged PRs carry each branch commit's subject as a
+                      # "* "-bulleted body line, so scanning every line lets one
+                      # merged PR (one cut commit per service) cut several services;
+                      # the line must START with the marker (after the bullet), so
+                      # prose mentioning a cut can never trigger a release.
+                      MATCHED_LINE=""
+                      while IFS= read -r LINE; do
+                          LINE="${LINE#\* }"
+                          case "$LINE" in
+                              "cut version ${TAG_PREFIX}"*)
+                                  MATCHED_LINE="$LINE"
+                                  break
+                                  ;;
+                          esac
+                      done <<< "$COMMIT_MESSAGE"
+                      if [ -n "$MATCHED_LINE" ]; then
+                          VERSION="${MATCHED_LINE#cut version }"
+                          VERSION="${VERSION%% *}"
+                          echo "version=$VERSION" >> $GITHUB_OUTPUT
+                          echo "matched=true" >> $GITHUB_OUTPUT
+                      else
+                          # Another service's cut (or a malformed subject): skip
+                          # cleanly instead of creating a colliding bare tag.
+                          echo "No message line starts with 'cut version ${TAG_PREFIX}' - not this service's cut, skipping."
+                          echo "version=" >> $GITHUB_OUTPUT
+                          echo "matched=false" >> $GITHUB_OUTPUT
+                      fi
                   fi
             # Namespaced releases scope their generated notes to this service's
             # previous tag; otherwise the notes would list every other service's

--- a/.github/workflows/tagandrelease.yml
+++ b/.github/workflows/tagandrelease.yml
@@ -52,6 +52,7 @@ jobs:
                       # prose mentioning a cut can never trigger a release.
                       MATCHED_LINE=""
                       while IFS= read -r LINE; do
+                          LINE="${LINE%$'\r'}" # tolerate CRLF commit messages
                           LINE="${LINE#\* }"
                           case "$LINE" in
                               "cut version ${TAG_PREFIX}"*)


### PR DESCRIPTION
## What

Namespaced mode (`prefix` set) now matches `cut version <prefix><version>` on **any line** of the head commit message, not just the subject. Per line: strip a trailing CR and one leading `* ` bullet, then the line must *start* with the marker; the version is everything after `cut version ` up to the first space. First matching line wins. Bare mode (no prefix) is byte-identical.

## Why

Squash-merge bodies carry each branch commit's subject as a `* `-bulleted line, so one release PR can now name several services and cut them all in a single merge — each caller matches only its own prefix, and callers not named skip green through the existing `matched=false` path (their downstream build jobs gate on a non-empty `version` output).

Companion caller-side change: SpalkLtd/bifrost#215.

## Contract

Releases:

```
cut version spalk-nginx/1.113.0 (#134)   → tag spalk-nginx/1.113.0
* cut version spalk-nginx/1.113.0        → tag spalk-nginx/1.113.0   (squash-body bullet)
```

Never releases: `Cut version …` (the scan is case-sensitive — lowercase is mandatory), wrong or missing `<service>/` namespace, mid-line or quoted mentions (`Revert "cut version …"`), `- ` bullets.

Sharp edges: any **flush-left** `cut version <prefix>` line is live, including squashed commit bodies; one version per service per merge (first marker wins); the caller-side gate still requires the squash *title* to start with `cut version`.

## Testing

Extraction logic exercised against legacy single-service titles (`(#N)` suffix), 4-service batch bodies, uncut prefixes, batch-title-alone, prose/revert mentions, and CRLF messages (byte-verified no `\r` reaches the tag). Independent review reproduced 12/12 documented cases; its requested CR-strip is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
